### PR TITLE
Squashed commit of the following:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # FUSE for Rust - Changelog
 
+## 0.16.0 - YYYY-MM-DD
+* **Major API Refactor**: The `Filesystem` trait methods have been refactored to return `Result<Output, Errno>` instead of using `Reply<T>` objects for callbacks.
+    * All `Filesystem` trait methods that previously accepted a `reply: ReplyXxx` parameter now return a `Result<XxxData, Errno>`, where `XxxData` is a struct containing the success data for that operation.
+    * The `Request` object passed to `Filesystem` methods has been replaced with `RequestMeta`, a smaller struct containing only the request's metadata (uid, gid, pid, unique id). The full request parsing is now handled internally.
+    * This change simplifies the implementation of `Filesystem` methods and makes error handling more explicit.
+    * Examples and internal request dispatch logic have been updated to match this new API.
+
 ## 0.15.1 - 2024-11-27
 * Fix crtime related panic that could occur on MacOS. See PR #322 for details.
 

--- a/examples/notify_inval_inode.rs
+++ b/examples/notify_inval_inode.rs
@@ -8,7 +8,7 @@
 
 use std::{
     convert::TryInto,
-    ffi::OsStr,
+    ffi::{OsStr, OsString},
     sync::{
         atomic::{AtomicU64, Ordering::SeqCst},
         Arc, Mutex,
@@ -17,13 +17,10 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use libc::{EACCES, EINVAL, EISDIR, ENOBUFS, ENOENT, ENOTDIR};
-
 use clap::Parser;
 
 use fuser::{
-    consts, FileAttr, FileType, Filesystem, MountOption, ReplyAttr, ReplyData, ReplyDirectory,
-    ReplyEntry, ReplyOpen, Request, FUSE_ROOT_ID,
+    consts, Attr, DirEntry, Entry, Errno, FileAttr, FileType, Filesystem, Forget, MountOption, Open, RequestMeta, FUSE_ROOT_ID
 };
 
 struct ClockFS<'a> {
@@ -31,7 +28,7 @@ struct ClockFS<'a> {
     lookup_cnt: &'a AtomicU64,
 }
 
-impl<'a> ClockFS<'a> {
+impl ClockFS<'_> {
     const FILE_INO: u64 = 2;
     const FILE_NAME: &'static str = "current_time";
 
@@ -66,102 +63,118 @@ impl<'a> ClockFS<'a> {
     }
 }
 
-impl<'a> Filesystem for ClockFS<'a> {
-    fn lookup(&mut self, _req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
-        if parent != FUSE_ROOT_ID || name != AsRef::<OsStr>::as_ref(&Self::FILE_NAME) {
-            reply.error(ENOENT);
-            return;
+impl Filesystem for ClockFS<'_> {
+    fn lookup(&mut self, _req: RequestMeta, parent: u64, name: OsString) -> Result<Entry, Errno> {
+        if parent != FUSE_ROOT_ID || name != OsStr::new(Self::FILE_NAME) {
+            return Err(Errno::ENOENT);
         }
 
         self.lookup_cnt.fetch_add(1, SeqCst);
-        reply.entry(&Duration::MAX, &self.stat(ClockFS::FILE_INO).unwrap(), 0);
-    }
-
-    fn forget(&mut self, _req: &Request, ino: u64, nlookup: u64) {
-        if ino == ClockFS::FILE_INO {
-            let prev = self.lookup_cnt.fetch_sub(nlookup, SeqCst);
-            assert!(prev >= nlookup);
-        } else {
-            assert!(ino == FUSE_ROOT_ID);
+        match self.stat(ClockFS::FILE_INO) {
+            Some(attr) => Ok(Entry {
+                    attr,
+                    ttl: Duration::MAX, // Effectively infinite TTL
+                    generation: 0,
+                }),
+            None => Err(Errno::EIO), // Should not happen
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
+    fn forget(&mut self, _req: RequestMeta, target: Forget) {
+        if target.ino == ClockFS::FILE_INO {
+            let prev = self.lookup_cnt.fetch_sub(target.nlookup, SeqCst);
+            assert!(prev >= target.nlookup);
+        } else {
+            assert!(target.ino == FUSE_ROOT_ID);
+        }
+    }
+
+    fn getattr(&mut self, _req: RequestMeta, ino: u64, _fh: Option<u64>) -> Result<Attr, Errno> {
         match self.stat(ino) {
-            Some(a) => reply.attr(&Duration::MAX, &a),
-            None => reply.error(ENOENT),
+            Some(attr) => Ok(Attr {
+                attr,
+                ttl: Duration::MAX, // Effectively infinite TTL
+            }),
+            None => Err(Errno::ENOENT),
         }
     }
 
     fn readdir(
         &mut self,
-        _req: &Request,
+        _req: RequestMeta,
         ino: u64,
         _fh: u64,
         offset: i64,
-        mut reply: ReplyDirectory,
-    ) {
+        _max_bytes: u32,
+    ) -> Result<Vec<DirEntry>, Errno> {
         if ino != FUSE_ROOT_ID {
-            reply.error(ENOTDIR);
-            return;
+            return Err(Errno::ENOTDIR);
         }
-
-        if offset == 0
-            && reply.add(
-                ClockFS::FILE_INO,
-                offset + 1,
-                FileType::RegularFile,
-                Self::FILE_NAME,
-            )
-        {
-            reply.error(ENOBUFS);
-        } else {
-            reply.ok();
+        let mut entries = Vec::new();
+        if offset == 0 {
+            entries.push(DirEntry {
+                ino: ClockFS::FILE_INO,
+                offset: 1, // Next offset
+                kind: FileType::RegularFile,
+                name: OsString::from(Self::FILE_NAME),
+            });
         }
+        // If offset is > 0, we've already returned the single entry, so return an empty vector.
+        Ok(entries)
     }
 
-    fn open(&mut self, _req: &Request, ino: u64, flags: i32, reply: ReplyOpen) {
+    fn open(&mut self, _req: RequestMeta, ino: u64, flags: i32) -> Result<Open, Errno> {
         if ino == FUSE_ROOT_ID {
-            reply.error(EISDIR);
+            Err(Errno::EISDIR)
         } else if flags & libc::O_ACCMODE != libc::O_RDONLY {
-            reply.error(EACCES);
+            Err(Errno::EACCES)
         } else if ino != Self::FILE_INO {
             eprintln!("Got open for nonexistent inode {}", ino);
-            reply.error(ENOENT);
+            Err(Errno::ENOENT)
         } else {
-            reply.opened(ino, consts::FOPEN_KEEP_CACHE);
+            Ok(Open {
+                fh: ino, // Using ino as fh, as it's unique for the file
+                flags: consts::FOPEN_KEEP_CACHE,
+            })
         }
     }
 
     fn read(
         &mut self,
-        _req: &Request,
+        _req: RequestMeta,
         ino: u64,
-        _fh: u64,
+        _fh: u64, // fh is ino in this implementation as set in open()
         offset: i64,
         size: u32,
         _flags: i32,
         _lock_owner: Option<u64>,
-        reply: ReplyData,
-    ) {
+    ) -> Result<Vec<u8>, Errno> {
         assert!(ino == Self::FILE_INO);
         if offset < 0 {
-            reply.error(EINVAL);
-            return;
+            return Err(Errno::EINVAL);
         }
         let file = self.file_contents.lock().unwrap();
         let filedata = file.as_bytes();
-        let dlen = filedata.len().try_into().unwrap();
-        let Ok(start) = offset.min(dlen).try_into() else {
-            reply.error(EINVAL);
-            return;
-        };
-        let Ok(end) = (offset + size as i64).min(dlen).try_into() else {
-            reply.error(EINVAL);
-            return;
-        };
-        eprintln!("read returning {} bytes at offset {}", end - start, offset);
-        reply.data(&filedata[start..end]);
+        let dlen: i64 = filedata.len().try_into().map_err(|_| Errno::EIO)?; // EIO if size doesn't fit i64
+
+        let start_offset: usize = offset.try_into().map_err(|_| Errno::EINVAL)?;
+        if start_offset > filedata.len() {
+             return Ok(Vec::new()); // Read past EOF
+        }
+
+        let end_offset: usize = (offset + i64::from(size))
+            .min(dlen) // cap at file length
+            .try_into()
+            .map_err(|_| Errno::EINVAL)?; // Should not fail if dlen fits usize
+
+        let actual_end = std::cmp::min(end_offset, filedata.len());
+
+        eprintln!(
+            "read returning {} bytes at offset {}",
+            actual_end.saturating_sub(start_offset),
+            offset
+        );
+        Ok(filedata[start_offset..actual_end].to_vec())
     }
 }
 

--- a/examples/passthrough.rs
+++ b/examples/passthrough.rs
@@ -4,12 +4,11 @@
 
 use clap::{crate_version, Arg, ArgAction, Command};
 use fuser::{
-    consts, BackingId, FileAttr, FileType, Filesystem, KernelConfig, MountOption, ReplyAttr,
-    ReplyDirectory, ReplyEmpty, ReplyEntry, ReplyOpen, Request,
+    consts, BackingId, FileAttr, FileType, Filesystem, KernelConfig, MountOption, Attr, DirEntry,
+    Entry, Open, Errno, RequestMeta,
 };
-use libc::ENOENT;
 use std::collections::HashMap;
-use std::ffi::{c_int, OsStr};
+use std::ffi::{OsString};
 use std::fs::File;
 use std::rc::{Rc, Weak};
 use std::time::{Duration, UNIX_EPOCH};
@@ -139,73 +138,85 @@ impl PassthroughFs {
 impl Filesystem for PassthroughFs {
     fn init(
         &mut self,
-        _req: &Request,
-        config: &mut KernelConfig,
-    ) -> std::result::Result<(), c_int> {
+        _req: RequestMeta,
+        config: KernelConfig,
+    ) -> Result<KernelConfig, Errno> {
+        let mut config = config;
         config.add_capabilities(consts::FUSE_PASSTHROUGH).unwrap();
         config.set_max_stack_depth(2).unwrap();
-        Ok(())
+        Ok(config)
     }
 
-    fn lookup(&mut self, _req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&mut self, _req: RequestMeta, parent: u64, name: OsString) -> Result<Entry, Errno> {
         if parent == 1 && name.to_str() == Some("passthrough") {
-            reply.entry(&TTL, &self.passthrough_file_attr, 0);
+            Ok(Entry {
+                attr: self.passthrough_file_attr,
+                ttl: TTL,
+                generation: 0,
+            })
         } else {
-            reply.error(ENOENT);
+            Err(Errno::ENOENT)
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
+    fn getattr(&mut self,
+        _req: RequestMeta,
+        ino: u64,
+        _fh: Option<u64>,
+    ) -> Result<Attr, Errno> {
         match ino {
-            1 => reply.attr(&TTL, &self.root_attr),
-            2 => reply.attr(&TTL, &self.passthrough_file_attr),
-            _ => reply.error(ENOENT),
+            1 => Ok(Attr{attr: self.root_attr, ttl: TTL}),
+            2 => Ok(Attr{attr: self.passthrough_file_attr, ttl: TTL}),
+            _ =>Err(Errno::ENOENT),
         }
     }
 
-    fn open(&mut self, _req: &Request, ino: u64, _flags: i32, reply: ReplyOpen) {
+    fn open(&mut self, _req: RequestMeta, ino: u64, _flags: i32) -> Result<Open, Errno> {
         if ino != 2 {
-            reply.error(ENOENT);
-            return;
+            return Err(Errno::ENOENT);
         }
 
         let (fh, id) = self
             .backing_cache
             .get_or(ino, || {
-                let file = File::open("/etc/os-release")?;
-                reply.open_backing(file)
+                let _file = File::open("/etc/os-release")?;
+                // TODO: Implement opening the backing file and returning appropriate
+                // information, possibly including a BackingId within the Open struct,
+                // or handle it through other means if fd-passthrough is intended here.
+                Err(std::io::Error::new(std::io::ErrorKind::Other, "TODO: passthrough open not fully implemented"))
             })
             .unwrap();
 
         eprintln!("  -> opened_passthrough({fh:?}, 0, {id:?});\n");
-        reply.opened_passthrough(fh, 0, &id);
+        // TODO: Ensure fd-passthrough is correctly set up if intended.
+        // The Open struct would carry necessary info.
+        // TODO: implement flags for Open struct
+        Ok(Open{fh, flags: 0 })
     }
 
     fn release(
         &mut self,
-        _req: &Request<'_>,
+        _req: RequestMeta,
         _ino: u64,
         fh: u64,
         _flags: i32,
         _lock_owner: Option<u64>,
         _flush: bool,
-        reply: ReplyEmpty,
-    ) {
+    ) -> Result<(), Errno> {
         self.backing_cache.put(fh);
-        reply.ok();
+        Ok(())
     }
 
     fn readdir(
         &mut self,
-        _req: &Request,
+        _req: RequestMeta,
         ino: u64,
         _fh: u64,
         offset: i64,
-        mut reply: ReplyDirectory,
-    ) {
+        _max_bytes: u32
+    ) -> Result<Vec<DirEntry>, Errno> {
         if ino != 1 {
-            reply.error(ENOENT);
-            return;
+            return Err(Errno::ENOENT);
         }
 
         let entries = vec![
@@ -213,14 +224,18 @@ impl Filesystem for PassthroughFs {
             (1, FileType::Directory, ".."),
             (2, FileType::RegularFile, "passthrough"),
         ];
+        let mut result=Vec::new();
 
         for (i, entry) in entries.into_iter().enumerate().skip(offset as usize) {
             // i + 1 means the index of the next entry
-            if reply.add(entry.0, (i + 1) as i64, entry.1, entry.2) {
-                break;
-            }
+            result.push(DirEntry {
+                ino: entry.0,
+                offset: i as i64 + 1,
+                kind: entry.1,
+                name: OsString::from(entry.2),
+            });
         }
-        reply.ok();
+        Ok(result)
     }
 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -9,9 +9,7 @@ use fuser::consts::FUSE_HANDLE_KILLPRIV;
 // use fuser::consts::FUSE_WRITE_KILL_PRIV;
 use fuser::TimeOrNow::Now;
 use fuser::{
-    Filesystem, KernelConfig, MountOption, ReplyAttr, ReplyCreate, ReplyData, ReplyDirectory,
-    ReplyEmpty, ReplyEntry, ReplyOpen, ReplyStatfs, ReplyWrite, ReplyXattr, Request, TimeOrNow,
-    FUSE_ROOT_ID,
+    Attr, DirEntry, Entry, Errno, Filesystem, Forget, KernelConfig, MountOption, Open, RequestMeta, Statfs, TimeOrNow, Xattr, FUSE_ROOT_ID
 };
 #[cfg(feature = "abi-7-26")]
 use log::info;
@@ -20,7 +18,7 @@ use log::{error, LevelFilter};
 use serde::{Deserialize, Serialize};
 use std::cmp::min;
 use std::collections::BTreeMap;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::os::raw::c_int;
@@ -130,16 +128,16 @@ fn xattr_access_check(
     key: &[u8],
     access_mask: i32,
     inode_attrs: &InodeAttributes,
-    request: &Request<'_>,
+    request: RequestMeta,
 ) -> Result<(), c_int> {
     match parse_xattr_namespace(key)? {
         XattrNamespace::Security => {
-            if access_mask != libc::R_OK && request.uid() != 0 {
+            if access_mask != libc::R_OK && request.uid != 0 {
                 return Err(libc::EPERM);
             }
         }
         XattrNamespace::Trusted => {
-            if request.uid() != 0 {
+            if request.uid != 0 {
                 return Err(libc::EPERM);
             }
         }
@@ -149,13 +147,15 @@ fn xattr_access_check(
                     inode_attrs.uid,
                     inode_attrs.gid,
                     inode_attrs.mode,
-                    request.uid(),
-                    request.gid(),
+                    request.uid,
+                    request.gid,
                     access_mask,
                 ) {
                     return Err(libc::EPERM);
                 }
-            } else if request.uid() != 0 {
+            } else if key.eq(b"system.posix_acl_default") | key.eq(b"system.nfs4_acl") {
+                return Err(libc::EOPNOTSUPP);
+            } else if request.uid != 0 {
                 return Err(libc::EPERM);
             }
         }
@@ -164,8 +164,8 @@ fn xattr_access_check(
                 inode_attrs.uid,
                 inode_attrs.gid,
                 inode_attrs.mode,
-                request.uid(),
-                request.gid(),
+                request.uid,
+                request.gid,
                 access_mask,
             ) {
                 return Err(libc::EPERM);
@@ -221,7 +221,7 @@ impl From<InodeAttributes> for fuser::FileAttr {
         fuser::FileAttr {
             ino: attrs.inode,
             size: attrs.size,
-            blocks: (attrs.size + BLOCK_SIZE - 1) / BLOCK_SIZE,
+            blocks: attrs.size.div_ceil(BLOCK_SIZE),
             atime: system_time_from_time(attrs.last_accessed.0, attrs.last_accessed.1),
             mtime: system_time_from_time(attrs.last_modified.0, attrs.last_modified.1),
             ctime: system_time_from_time(
@@ -248,6 +248,7 @@ struct SimpleFS {
     next_file_handle: AtomicU64,
     direct_io: bool,
     suid_support: bool,
+    usermode: bool
 }
 
 impl SimpleFS {
@@ -255,6 +256,7 @@ impl SimpleFS {
         data_dir: String,
         direct_io: bool,
         #[allow(unused_variables)] suid_support: bool,
+        usermode: bool
     ) -> SimpleFS {
         #[cfg(feature = "abi-7-26")]
         {
@@ -263,6 +265,7 @@ impl SimpleFS {
                 next_file_handle: AtomicU64::new(1),
                 direct_io,
                 suid_support,
+                usermode,
             }
         }
         #[cfg(not(feature = "abi-7-26"))]
@@ -272,6 +275,7 @@ impl SimpleFS {
                 next_file_handle: AtomicU64::new(1),
                 direct_io,
                 suid_support: false,
+                usermode,
             }
         }
     }
@@ -431,7 +435,7 @@ impl SimpleFS {
         Ok(attrs)
     }
 
-    fn lookup_name(&self, parent: u64, name: &OsStr) -> Result<InodeAttributes, c_int> {
+    fn lookup_name(&self, parent: u64, name: &OsString) -> Result<InodeAttributes, c_int> {
         let entries = self.get_directory_content(parent)?;
         if let Some((inode, _)) = entries.get(name.as_bytes()) {
             return self.get_inode(*inode);
@@ -442,13 +446,13 @@ impl SimpleFS {
 
     fn insert_link(
         &self,
-        req: &Request,
+        req: RequestMeta,
         parent: u64,
-        name: &OsStr,
+        name: OsString,
         inode: u64,
         kind: FileKind,
     ) -> Result<(), c_int> {
-        if self.lookup_name(parent, name).is_ok() {
+        if self.lookup_name(parent, &name).is_ok() {
             return Err(libc::EEXIST);
         }
 
@@ -458,8 +462,8 @@ impl SimpleFS {
             parent_attrs.uid,
             parent_attrs.gid,
             parent_attrs.mode,
-            req.uid(),
-            req.gid(),
+            req.uid,
+            req.gid,
             libc::W_OK,
         ) {
             return Err(libc::EACCES);
@@ -479,16 +483,29 @@ impl SimpleFS {
 impl Filesystem for SimpleFS {
     fn init(
         &mut self,
-        _req: &Request,
-        #[allow(unused_variables)] config: &mut KernelConfig,
-    ) -> Result<(), c_int> {
+        _req: RequestMeta,
+        config: KernelConfig,
+    ) -> Result<KernelConfig, Errno> {
         #[cfg(feature = "abi-7-26")]
-        config.add_capabilities(FUSE_HANDLE_KILLPRIV).unwrap();
-
+        let config = {
+            let mut config = config;
+            config.add_capabilities(FUSE_HANDLE_KILLPRIV).unwrap();
+            config
+        };
         fs::create_dir_all(Path::new(&self.data_dir).join("inodes")).unwrap();
         fs::create_dir_all(Path::new(&self.data_dir).join("contents")).unwrap();
         if self.get_inode(FUSE_ROOT_ID).is_err() {
             // Initialize with empty filesystem
+            let (init_uid, init_gid, init_mode) = if self.usermode  {
+                // root dir: owned by current user, private
+                use libc::{getuid, getgid};
+                let current_uid = unsafe { getuid() };
+                let current_gid = unsafe { getgid() };
+                (current_uid, current_gid, 0o700)
+            } else {
+                // root dir: owned by root user, world writable
+                (0, 0, 0o777)
+            };
             let root = InodeAttributes {
                 inode: FUSE_ROOT_ID,
                 open_file_handles: 0,
@@ -497,10 +514,10 @@ impl Filesystem for SimpleFS {
                 last_modified: time_now(),
                 last_metadata_changed: time_now(),
                 kind: FileKind::Directory,
-                mode: 0o777,
+                mode: init_mode,
                 hardlinks: 2,
-                uid: 0,
-                gid: 0,
+                uid: init_uid,
+                gid: init_gid,
                 xattrs: Default::default(),
             };
             self.write_inode(&root);
@@ -508,77 +525,92 @@ impl Filesystem for SimpleFS {
             entries.insert(b".".to_vec(), (FUSE_ROOT_ID, FileKind::Directory));
             self.write_directory_content(FUSE_ROOT_ID, entries);
         }
-        Ok(())
+        Ok(config)
     }
 
-    fn lookup(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
+    fn destroy(&mut self) {}
+
+    fn lookup(&mut self, req: RequestMeta, parent: u64, name: OsString) -> Result<Entry, Errno> {
         if name.len() > MAX_NAME_LENGTH as usize {
-            reply.error(libc::ENAMETOOLONG);
-            return;
+            return Err(Errno::ENAMETOOLONG);
         }
-        let parent_attrs = self.get_inode(parent).unwrap();
+        let parent_attrs = match self.get_inode(parent) {
+            Ok(attrs) => attrs,
+            Err(e) => {
+                return Err(Errno::from_i32(e));
+            }
+        };
         if !check_access(
             parent_attrs.uid,
             parent_attrs.gid,
             parent_attrs.mode,
-            req.uid(),
-            req.gid(),
+            req.uid, 
+            req.gid,
             libc::X_OK,
         ) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
-        match self.lookup_name(parent, name) {
-            Ok(attrs) => reply.entry(&Duration::new(0, 0), &attrs.into(), 0),
-            Err(error_code) => reply.error(error_code),
+        match self.lookup_name(parent, &name) {
+            Ok(attrs) => Ok(Entry {
+                attr: attrs.into(),
+                ttl: Duration::new(0,0),
+                generation: 0,
+            }),
+            Err(error_code) => Err(Errno::from_i32(error_code)),
         }
     }
 
-    fn forget(&mut self, _req: &Request, _ino: u64, _nlookup: u64) {}
+    fn forget(&mut self, _req: RequestMeta, _target: Forget) {}
 
-    fn getattr(&mut self, _req: &Request, inode: u64, _fh: Option<u64>, reply: ReplyAttr) {
-        match self.get_inode(inode) {
-            Ok(attrs) => reply.attr(&Duration::new(0, 0), &attrs.into()),
-            Err(error_code) => reply.error(error_code),
+    fn getattr(
+        &mut self,
+        _req: RequestMeta,
+        ino: u64,
+        _fh: Option<u64>,
+    ) -> Result<Attr, Errno> {
+        match self.get_inode(ino) {
+            Ok(inode) => 
+                Ok(Attr {
+                    attr: inode.into(), 
+                    ttl: Duration::new(0, 0), 
+                }),
+            Err(e) => Err(Errno::from_i32(e)),
         }
     }
 
     fn setattr(
         &mut self,
-        req: &Request,
+        req: RequestMeta,
         inode: u64,
-        mode: Option<u32>,
-        uid: Option<u32>,
-        gid: Option<u32>,
-        size: Option<u64>,
-        atime: Option<TimeOrNow>,
-        mtime: Option<TimeOrNow>,
+        mode_option: Option<u32>,
+        uid_option: Option<u32>,
+        gid_option: Option<u32>,
+        size_option: Option<u64>,
+        atime_option: Option<TimeOrNow>,
+        mtime_option: Option<TimeOrNow>,
         _ctime: Option<SystemTime>,
         fh: Option<u64>,
         _crtime: Option<SystemTime>,
         _chgtime: Option<SystemTime>,
         _bkuptime: Option<SystemTime>,
         _flags: Option<u32>,
-        reply: ReplyAttr,
-    ) {
+    ) -> Result<Attr, Errno> {
         let mut attrs = match self.get_inode(inode) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
-        if let Some(mode) = mode {
+        if let Some(mode) = mode_option {
             debug!("chmod() called with {:?}, {:o}", inode, mode);
-            if req.uid() != 0 && req.uid() != attrs.uid {
-                reply.error(libc::EPERM);
-                return;
+            if req.uid != 0 && req.uid != attrs.uid {
+                return Err(Errno::EPERM);
             }
-            if req.uid() != 0
-                && req.gid() != attrs.gid
-                && !get_groups(req.pid()).contains(&attrs.gid)
+            if req.uid != 0
+                && req.gid != attrs.gid
+                && !get_groups(req.pid).contains(&attrs.gid)
             {
                 // If SGID is set and the file belongs to a group that the caller is not part of
                 // then the SGID bit is suppose to be cleared during chmod
@@ -588,32 +620,31 @@ impl Filesystem for SimpleFS {
             }
             attrs.last_metadata_changed = time_now();
             self.write_inode(&attrs);
-            reply.attr(&Duration::new(0, 0), &attrs.into());
-            return;
+            return Ok(Attr { 
+                attr: attrs.into(), 
+                ttl: Duration::new(0,0),
+            });
         }
 
-        if uid.is_some() || gid.is_some() {
-            debug!("chown() called with {:?} {:?} {:?}", inode, uid, gid);
-            if let Some(gid) = gid {
+        if uid_option.is_some() || gid_option.is_some() {
+            debug!("chown() called with {:?} {:?} {:?}", inode, uid_option, gid_option);
+            if let Some(gid) = gid_option {
                 // Non-root users can only change gid to a group they're in
-                if req.uid() != 0 && !get_groups(req.pid()).contains(&gid) {
-                    reply.error(libc::EPERM);
-                    return;
+                if req.uid != 0 && !get_groups(req.pid).contains(&gid) {
+                    return Err(Errno::EPERM);
                 }
             }
-            if let Some(uid) = uid {
-                if req.uid() != 0
+            if let Some(uid) = uid_option {
+                if req.uid != 0
                     // but no-op changes by the owner are not an error
-                    && !(uid == attrs.uid && req.uid() == attrs.uid)
+                    && !(uid == attrs.uid && req.uid == attrs.uid)
                 {
-                    reply.error(libc::EPERM);
-                    return;
+                    return Err(Errno::EPERM);
                 }
             }
             // Only owner may change the group
-            if gid.is_some() && req.uid() != 0 && req.uid() != attrs.uid {
-                reply.error(libc::EPERM);
-                return;
+            if gid_option.is_some() && req.uid != 0 && req.uid != attrs.uid {
+                return Err(Errno::EPERM);
             }
 
             if attrs.mode & (libc::S_IXUSR | libc::S_IXGRP | libc::S_IXOTH) as u16 != 0 {
@@ -621,67 +652,61 @@ impl Filesystem for SimpleFS {
                 clear_suid_sgid(&mut attrs);
             }
 
-            if let Some(uid) = uid {
+            if let Some(uid) = uid_option {
                 attrs.uid = uid;
                 // Clear SETUID on owner change
                 attrs.mode &= !libc::S_ISUID as u16;
             }
-            if let Some(gid) = gid {
+            if let Some(gid) = gid_option {
                 attrs.gid = gid;
                 // Clear SETGID unless user is root
-                if req.uid() != 0 {
+                if req.uid != 0 {
                     attrs.mode &= !libc::S_ISGID as u16;
                 }
             }
             attrs.last_metadata_changed = time_now();
             self.write_inode(&attrs);
-            reply.attr(&Duration::new(0, 0), &attrs.into());
-            return;
+            return Ok(Attr { attr: attrs.into(), ttl: Duration::new(0,0),  });
         }
 
-        if let Some(size) = size {
+        if let Some(size) = size_option {
             debug!("truncate() called with {:?} {:?}", inode, size);
-            if let Some(handle) = fh {
-                // If the file handle is available, check access locally.
-                // This is important as it preserves the semantic that a file handle opened
-                // with W_OK will never fail to truncate, even if the file has been subsequently
-                // chmod'ed
+            let truncated_attrs_result = if let Some(handle) = fh {
                 if self.check_file_handle_write(handle) {
-                    if let Err(error_code) = self.truncate(inode, size, 0, 0) {
-                        reply.error(error_code);
-                        return;
-                    }
+                    self.truncate(inode, size, 0, 0)
                 } else {
-                    reply.error(libc::EACCES);
-                    return;
+                    return Err(Errno::EACCES);
                 }
-            } else if let Err(error_code) = self.truncate(inode, size, req.uid(), req.gid()) {
-                reply.error(error_code);
-                return;
-            }
+            } else {
+                self.truncate(inode, size, req.uid, req.gid)
+            };
+    
+            return match truncated_attrs_result {
+                Ok(current_attrs) => Ok(Attr { attr: current_attrs.into(), ttl: Duration::new(0,0), }),
+                Err(error_code) => Err(Errno::from_i32(error_code)),
+            };
         }
-
+        // Note: If any of the above attributes were changed, the remaining part is not reached.
         let now = time_now();
-        if let Some(atime) = atime {
+        let mut modified_time_attr = false;
+        if let Some(atime) = atime_option {
             debug!("utimens() called with {:?}, atime={:?}", inode, atime);
 
-            if attrs.uid != req.uid() && req.uid() != 0 && atime != Now {
-                reply.error(libc::EPERM);
-                return;
+            if attrs.uid != req.uid && req.uid != 0 && atime != Now {
+                return Err(Errno::EPERM);
             }
 
-            if attrs.uid != req.uid()
+            if attrs.uid != req.uid
                 && !check_access(
                     attrs.uid,
                     attrs.gid,
                     attrs.mode,
-                    req.uid(),
-                    req.gid(),
+                    req.uid,
+                    req.gid,
                     libc::W_OK,
                 )
             {
-                reply.error(libc::EACCES);
-                return;
+                return Err(Errno::EACCES);
             }
 
             attrs.last_accessed = match atime {
@@ -689,28 +714,26 @@ impl Filesystem for SimpleFS {
                 Now => now,
             };
             attrs.last_metadata_changed = now;
-            self.write_inode(&attrs);
+            modified_time_attr = true;
         }
-        if let Some(mtime) = mtime {
+        if let Some(mtime) = mtime_option {
             debug!("utimens() called with {:?}, mtime={:?}", inode, mtime);
 
-            if attrs.uid != req.uid() && req.uid() != 0 && mtime != Now {
-                reply.error(libc::EPERM);
-                return;
+            if attrs.uid != req.uid && req.uid != 0 && mtime != Now {
+                return Err(Errno::EPERM);
             }
 
-            if attrs.uid != req.uid()
+            if attrs.uid != req.uid
                 && !check_access(
                     attrs.uid,
                     attrs.gid,
                     attrs.mode,
-                    req.uid(),
-                    req.gid(),
+                    req.uid,
+                    req.gid,
                     libc::W_OK,
                 )
             {
-                reply.error(libc::EACCES);
-                return;
+                return Err(Errno::EACCES);
             }
 
             attrs.last_modified = match mtime {
@@ -718,37 +741,47 @@ impl Filesystem for SimpleFS {
                 Now => now,
             };
             attrs.last_metadata_changed = now;
+            modified_time_attr = true;
+        }
+
+        if modified_time_attr {
             self.write_inode(&attrs);
         }
 
-        let attrs = self.get_inode(inode).unwrap();
-        reply.attr(&Duration::new(0, 0), &attrs.into());
-        return;
+        // If atime/mtime were set, or if no attributes were set,
+        // we fetch the latest attributes and return them.
+        let final_attrs = self.get_inode(inode).map_err(Errno::from_i32)?;
+        Ok(Attr { attr: final_attrs.into(), ttl: Duration::new(0,0), })
     }
 
-    fn readlink(&mut self, _req: &Request, inode: u64, reply: ReplyData) {
+    fn readlink(&mut self, _req: RequestMeta, inode: u64) -> Result<Vec<u8>, Errno> {
         debug!("readlink() called on {:?}", inode);
         let path = self.content_path(inode);
-        if let Ok(mut file) = File::open(path) {
-            let file_size = file.metadata().unwrap().len();
-            let mut buffer = vec![0; file_size as usize];
-            file.read_exact(&mut buffer).unwrap();
-            reply.data(&buffer);
-        } else {
-            reply.error(libc::ENOENT);
+        match File::open(path) {
+            Ok(mut file) => {
+                let file_size = match file.metadata() {
+                    Ok(md) => md.len(),
+                    Err(_) => return Err(Errno::EIO), // Or some other appropriate error
+                };
+                let mut buffer = vec![0; file_size as usize];
+                match file.read_exact(&mut buffer) {
+                    Ok(_) => Ok(buffer),
+                    Err(_) => Err(Errno::EIO), // Or some other appropriate error
+                }
+            }
+            Err(_) => Err(Errno::ENOENT),
         }
     }
 
     fn mknod(
         &mut self,
-        req: &Request,
+        req: RequestMeta,
         parent: u64,
-        name: &OsStr,
-        mut mode: u32,
+        name: OsString,
+        mode: u32,
         _umask: u32,
         _rdev: u32,
-        reply: ReplyEntry,
-    ) {
+    ) -> Result<Entry, Errno> {
         let file_type = mode & libc::S_IFMT as u32;
 
         if file_type != libc::S_IFREG as u32
@@ -757,20 +790,17 @@ impl Filesystem for SimpleFS {
         {
             // TODO
             warn!("mknod() implementation is incomplete. Only supports regular files, symlinks, and directories. Got {:o}", mode);
-            reply.error(libc::EPERM);
-            return;
+            return Err(Errno::EPERM);
         }
 
-        if self.lookup_name(parent, name).is_ok() {
-            reply.error(libc::EEXIST);
-            return;
+        if self.lookup_name(parent, &name).is_ok() {
+            return Err(Errno::EEXIST);
         }
 
         let mut parent_attrs = match self.get_inode(parent) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
@@ -778,20 +808,22 @@ impl Filesystem for SimpleFS {
             parent_attrs.uid,
             parent_attrs.gid,
             parent_attrs.mode,
-            req.uid(),
-            req.gid(),
+            req.uid,
+            req.gid,
             libc::W_OK,
         ) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
         parent_attrs.last_modified = time_now();
         parent_attrs.last_metadata_changed = time_now();
         self.write_inode(&parent_attrs);
 
-        if req.uid() != 0 {
-            mode &= !(libc::S_ISUID | libc::S_ISGID) as u32;
-        }
+        let new_mode = if req.uid != 0 {
+            // regular users may not set uid or set gid
+            mode & !(libc::S_ISUID | libc::S_ISGID) as u32
+        } else {
+            mode
+        };
 
         let inode = self.allocate_next_inode();
         let attrs = InodeAttributes {
@@ -801,51 +833,51 @@ impl Filesystem for SimpleFS {
             last_accessed: time_now(),
             last_modified: time_now(),
             last_metadata_changed: time_now(),
-            kind: as_file_kind(mode),
-            mode: self.creation_mode(mode),
+            kind: as_file_kind(new_mode),
+            mode: self.creation_mode(new_mode),
             hardlinks: 1,
-            uid: req.uid(),
-            gid: creation_gid(&parent_attrs, req.gid()),
+            uid: req.uid,
+            gid: creation_gid(&parent_attrs, req.gid),
             xattrs: Default::default(),
         };
         self.write_inode(&attrs);
-        File::create(self.content_path(inode)).unwrap();
+        File::create(self.content_path(inode)).map_err(|_| Errno::EIO)?;
 
-        if as_file_kind(mode) == FileKind::Directory {
+        if as_file_kind(new_mode) == FileKind::Directory {
             let mut entries = BTreeMap::new();
             entries.insert(b".".to_vec(), (inode, FileKind::Directory));
             entries.insert(b"..".to_vec(), (parent, FileKind::Directory));
             self.write_directory_content(inode, entries);
         }
 
-        let mut entries = self.get_directory_content(parent).unwrap();
+        let mut entries = self.get_directory_content(parent).map_err(Errno::from_i32)?;
         entries.insert(name.as_bytes().to_vec(), (inode, attrs.kind));
         self.write_directory_content(parent, entries);
 
-        // TODO: implement flags
-        reply.entry(&Duration::new(0, 0), &attrs.into(), 0);
+        Ok(Entry {
+            attr: attrs.into(),
+            ttl: Duration::new(0,0),
+            generation: 0,
+        })
     }
 
     fn mkdir(
         &mut self,
-        req: &Request,
+        req: RequestMeta,
         parent: u64,
-        name: &OsStr,
-        mut mode: u32,
-        _umask: u32,
-        reply: ReplyEntry,
-    ) {
+        name: OsString,
+        mode: u32,
+        #[allow(unused_variables)] _umask: u32,
+    ) -> Result<Entry, Errno> {
         debug!("mkdir() called with {:?} {:?} {:o}", parent, name, mode);
-        if self.lookup_name(parent, name).is_ok() {
-            reply.error(libc::EEXIST);
-            return;
+        if self.lookup_name(parent, &name).is_ok() {
+            return Err(Errno::EEXIST);
         }
 
         let mut parent_attrs = match self.get_inode(parent) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
@@ -853,23 +885,25 @@ impl Filesystem for SimpleFS {
             parent_attrs.uid,
             parent_attrs.gid,
             parent_attrs.mode,
-            req.uid(),
-            req.gid(),
+            req.uid,
+            req.gid,
             libc::W_OK,
         ) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
         parent_attrs.last_modified = time_now();
         parent_attrs.last_metadata_changed = time_now();
         self.write_inode(&parent_attrs);
-
-        if req.uid() != 0 {
-            mode &= !(libc::S_ISUID | libc::S_ISGID) as u32;
-        }
-        if parent_attrs.mode & libc::S_ISGID as u16 != 0 {
-            mode |= libc::S_ISGID as u32;
-        }
+    
+        let new_mode = if req.uid != 0 {
+            // regular users may not set uid or set gid
+            mode & !(libc::S_ISUID | libc::S_ISGID) as u32
+        } else if parent_attrs.mode & libc::S_ISGID as u16 != 0 {
+            // root user must set gid if the parent diretory does
+            mode | libc::S_ISGID as u32
+        } else {
+            mode
+        };
 
         let inode = self.allocate_next_inode();
         let attrs = InodeAttributes {
@@ -880,10 +914,10 @@ impl Filesystem for SimpleFS {
             last_modified: time_now(),
             last_metadata_changed: time_now(),
             kind: FileKind::Directory,
-            mode: self.creation_mode(mode),
+            mode: self.creation_mode(new_mode),
             hardlinks: 2, // Directories start with link count of 2, since they have a self link
-            uid: req.uid(),
-            gid: creation_gid(&parent_attrs, req.gid()),
+            uid: req.uid,
+            gid: creation_gid(&parent_attrs, req.gid),
             xattrs: Default::default(),
         };
         self.write_inode(&attrs);
@@ -893,28 +927,30 @@ impl Filesystem for SimpleFS {
         entries.insert(b"..".to_vec(), (parent, FileKind::Directory));
         self.write_directory_content(inode, entries);
 
-        let mut entries = self.get_directory_content(parent).unwrap();
+        let mut entries = self.get_directory_content(parent).map_err(Errno::from_i32)?;
         entries.insert(name.as_bytes().to_vec(), (inode, FileKind::Directory));
         self.write_directory_content(parent, entries);
 
-        reply.entry(&Duration::new(0, 0), &attrs.into(), 0);
+        Ok(Entry {
+            attr: attrs.into(),
+            ttl: Duration::new(0,0),
+            generation: 0,
+        })
     }
 
-    fn unlink(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEmpty) {
+    fn unlink(&mut self, req: RequestMeta, parent: u64, name: OsString) -> Result<(), Errno> {
         debug!("unlink() called with {:?} {:?}", parent, name);
-        let mut attrs = match self.lookup_name(parent, name) {
+        let mut attrs = match self.lookup_name(parent, &name) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
         let mut parent_attrs = match self.get_inode(parent) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
@@ -922,23 +958,21 @@ impl Filesystem for SimpleFS {
             parent_attrs.uid,
             parent_attrs.gid,
             parent_attrs.mode,
-            req.uid(),
-            req.gid(),
+            req.uid,
+            req.gid,
             libc::W_OK,
         ) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
-        let uid = req.uid();
+        let uid = req.uid;
         // "Sticky bit" handling
         if parent_attrs.mode & libc::S_ISVTX as u16 != 0
             && uid != 0
             && uid != parent_attrs.uid
             && uid != attrs.uid
         {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
         parent_attrs.last_metadata_changed = time_now();
@@ -954,52 +988,52 @@ impl Filesystem for SimpleFS {
         entries.remove(name.as_bytes());
         self.write_directory_content(parent, entries);
 
-        reply.ok();
+        Ok(())
     }
 
-    fn rmdir(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEmpty) {
+    fn rmdir(&mut self, req: RequestMeta, parent: u64, name: OsString) -> Result<(), Errno> {
         debug!("rmdir() called with {:?} {:?}", parent, name);
-        let mut attrs = match self.lookup_name(parent, name) {
+        let mut attrs = match self.lookup_name(parent, &name) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
         let mut parent_attrs = match self.get_inode(parent) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
         // Directories always have a self and parent link
-        if self.get_directory_content(attrs.inode).unwrap().len() > 2 {
-            reply.error(libc::ENOTEMPTY);
-            return;
+        match self.get_directory_content(attrs.inode) {
+            Ok(dir_entries) => {
+                if dir_entries.len() > 2 {
+                    return Err(Errno::ENOTEMPTY);
+                }
+            }
+            Err(e) => return Err(Errno::from_i32(e)),
         }
         if !check_access(
             parent_attrs.uid,
             parent_attrs.gid,
             parent_attrs.mode,
-            req.uid(),
-            req.gid(),
+            req.uid,
+            req.gid,
             libc::W_OK,
         ) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
         // "Sticky bit" handling
         if parent_attrs.mode & libc::S_ISVTX as u16 != 0
-            && req.uid() != 0
-            && req.uid() != parent_attrs.uid
-            && req.uid() != attrs.uid
+            && req.uid != 0
+            && req.uid != parent_attrs.uid
+            && req.uid != attrs.uid
         {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
         parent_attrs.last_metadata_changed = time_now();
@@ -1011,21 +1045,20 @@ impl Filesystem for SimpleFS {
         self.write_inode(&attrs);
         self.gc_inode(&attrs);
 
-        let mut entries = self.get_directory_content(parent).unwrap();
+    let mut entries = self.get_directory_content(parent).map_err(Errno::from_i32)?;
         entries.remove(name.as_bytes());
         self.write_directory_content(parent, entries);
 
-        reply.ok();
+        Ok(())
     }
 
     fn symlink(
         &mut self,
-        req: &Request,
+        req: RequestMeta,
         parent: u64,
-        link_name: &OsStr,
-        target: &Path,
-        reply: ReplyEntry,
-    ) {
+        link_name: OsString,
+        target: PathBuf,
+    ) -> Result<Entry, Errno> {
         debug!(
             "symlink() called with {:?} {:?} {:?}",
             parent, link_name, target
@@ -1033,8 +1066,7 @@ impl Filesystem for SimpleFS {
         let mut parent_attrs = match self.get_inode(parent) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
@@ -1042,12 +1074,11 @@ impl Filesystem for SimpleFS {
             parent_attrs.uid,
             parent_attrs.gid,
             parent_attrs.mode,
-            req.uid(),
-            req.gid(),
+            req.uid,
+            req.gid,
             libc::W_OK,
         ) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
         parent_attrs.last_modified = time_now();
         parent_attrs.last_metadata_changed = time_now();
@@ -1064,15 +1095,14 @@ impl Filesystem for SimpleFS {
             kind: FileKind::Symlink,
             mode: 0o777,
             hardlinks: 1,
-            uid: req.uid(),
-            gid: creation_gid(&parent_attrs, req.gid()),
+            uid: req.uid,
+            gid: creation_gid(&parent_attrs, req.gid),
             xattrs: Default::default(),
         };
 
         if let Err(error_code) = self.insert_link(req, parent, link_name, inode, FileKind::Symlink)
         {
-            reply.error(error_code);
-            return;
+            return Err(Errno::from_i32(error_code));
         }
         self.write_inode(&attrs);
 
@@ -1082,39 +1112,40 @@ impl Filesystem for SimpleFS {
             .create(true)
             .truncate(true)
             .open(path)
-            .unwrap();
-        file.write_all(target.as_os_str().as_bytes()).unwrap();
+            .map_err(|_| Errno::EIO)?;
+        file.write_all(target.as_os_str().as_bytes()).map_err(|_| Errno::EIO)?;
 
-        reply.entry(&Duration::new(0, 0), &attrs.into(), 0);
+        Ok(Entry {
+            attr: attrs.into(),
+            ttl: Duration::new(0,0),
+            generation: 0,
+        })
     }
 
     fn rename(
         &mut self,
-        req: &Request,
+        req: RequestMeta,
         parent: u64,
-        name: &OsStr,
+        name: OsString,
         new_parent: u64,
-        new_name: &OsStr,
+        new_name: OsString,
         flags: u32,
-        reply: ReplyEmpty,
-    ) {
+    ) -> Result<(), Errno> {
         debug!(
             "rename() called with: source {parent:?} {name:?}, \
             destination {new_parent:?} {new_name:?}, flags {flags:#b}",
         );
-        let mut inode_attrs = match self.lookup_name(parent, name) {
+        let mut inode_attrs = match self.lookup_name(parent, &name) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
         let mut parent_attrs = match self.get_inode(parent) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
@@ -1122,29 +1153,26 @@ impl Filesystem for SimpleFS {
             parent_attrs.uid,
             parent_attrs.gid,
             parent_attrs.mode,
-            req.uid(),
-            req.gid(),
+            req.uid,
+            req.gid,
             libc::W_OK,
         ) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
         // "Sticky bit" handling
         if parent_attrs.mode & libc::S_ISVTX as u16 != 0
-            && req.uid() != 0
-            && req.uid() != parent_attrs.uid
-            && req.uid() != inode_attrs.uid
+            && req.uid != 0
+            && req.uid != parent_attrs.uid
+            && req.uid != inode_attrs.uid
         {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
         let mut new_parent_attrs = match self.get_inode(new_parent) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
@@ -1152,45 +1180,42 @@ impl Filesystem for SimpleFS {
             new_parent_attrs.uid,
             new_parent_attrs.gid,
             new_parent_attrs.mode,
-            req.uid(),
-            req.gid(),
+            req.uid,
+            req.gid,
             libc::W_OK,
         ) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
         // "Sticky bit" handling in new_parent
         if new_parent_attrs.mode & libc::S_ISVTX as u16 != 0 {
-            if let Ok(existing_attrs) = self.lookup_name(new_parent, new_name) {
-                if req.uid() != 0
-                    && req.uid() != new_parent_attrs.uid
-                    && req.uid() != existing_attrs.uid
+            if let Ok(existing_attrs) = self.lookup_name(new_parent, &new_name) {
+                if req.uid != 0
+                    && req.uid != new_parent_attrs.uid
+                    && req.uid != existing_attrs.uid
                 {
-                    reply.error(libc::EACCES);
-                    return;
+                    return Err(Errno::EACCES);
                 }
             }
         }
 
         #[cfg(target_os = "linux")]
         if flags & libc::RENAME_EXCHANGE as u32 != 0 {
-            let mut new_inode_attrs = match self.lookup_name(new_parent, new_name) {
+            let mut new_inode_attrs = match self.lookup_name(new_parent, &new_name) {
                 Ok(attrs) => attrs,
                 Err(error_code) => {
-                    reply.error(error_code);
-                    return;
+                    return Err(Errno::from_i32(error_code));
                 }
             };
 
-            let mut entries = self.get_directory_content(new_parent).unwrap();
+            let mut entries = self.get_directory_content(new_parent).map_err(Errno::from_i32)?;
             entries.insert(
                 new_name.as_bytes().to_vec(),
                 (inode_attrs.inode, inode_attrs.kind),
             );
             self.write_directory_content(new_parent, entries);
 
-            let mut entries = self.get_directory_content(parent).unwrap();
+            let mut entries = self.get_directory_content(parent).map_err(Errno::from_i32)?;
             entries.insert(
                 name.as_bytes().to_vec(),
                 (new_inode_attrs.inode, new_inode_attrs.kind),
@@ -1209,31 +1234,26 @@ impl Filesystem for SimpleFS {
             self.write_inode(&new_inode_attrs);
 
             if inode_attrs.kind == FileKind::Directory {
-                let mut entries = self.get_directory_content(inode_attrs.inode).unwrap();
+                let mut entries = self.get_directory_content(inode_attrs.inode).map_err(Errno::from_i32)?;
                 entries.insert(b"..".to_vec(), (new_parent, FileKind::Directory));
                 self.write_directory_content(inode_attrs.inode, entries);
             }
             if new_inode_attrs.kind == FileKind::Directory {
-                let mut entries = self.get_directory_content(new_inode_attrs.inode).unwrap();
+                let mut entries = self.get_directory_content(new_inode_attrs.inode).map_err(Errno::from_i32)?;
                 entries.insert(b"..".to_vec(), (parent, FileKind::Directory));
                 self.write_directory_content(new_inode_attrs.inode, entries);
             }
 
-            reply.ok();
-            return;
+            return Ok(());
         }
 
         // Only overwrite an existing directory if it's empty
-        if let Ok(new_name_attrs) = self.lookup_name(new_parent, new_name) {
-            if new_name_attrs.kind == FileKind::Directory
-                && self
-                    .get_directory_content(new_name_attrs.inode)
-                    .unwrap()
-                    .len()
-                    > 2
-            {
-                reply.error(libc::ENOTEMPTY);
-                return;
+        if let Ok(new_name_attrs) = self.lookup_name(new_parent, &new_name) {
+            if new_name_attrs.kind == FileKind::Directory {
+                let dir_entries = self.get_directory_content(new_name_attrs.inode).map_err(Errno::from_i32)?;
+                if dir_entries.len() > 2 {
+                    return Err(Errno::ENOTEMPTY);
+                }
             }
         }
 
@@ -1245,18 +1265,17 @@ impl Filesystem for SimpleFS {
                 inode_attrs.uid,
                 inode_attrs.gid,
                 inode_attrs.mode,
-                req.uid(),
-                req.gid(),
+                req.uid,
+                req.gid,
                 libc::W_OK,
             )
         {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
         // If target already exists decrement its hardlink count
-        if let Ok(mut existing_inode_attrs) = self.lookup_name(new_parent, new_name) {
-            let mut entries = self.get_directory_content(new_parent).unwrap();
+        if let Ok(mut existing_inode_attrs) = self.lookup_name(new_parent, &new_name) {
+            let mut entries = self.get_directory_content(new_parent).map_err(Errno::from_i32)?;
             entries.remove(new_name.as_bytes());
             self.write_directory_content(new_parent, entries);
 
@@ -1270,11 +1289,11 @@ impl Filesystem for SimpleFS {
             self.gc_inode(&existing_inode_attrs);
         }
 
-        let mut entries = self.get_directory_content(parent).unwrap();
+        let mut entries = self.get_directory_content(parent).map_err(Errno::from_i32)?;
         entries.remove(name.as_bytes());
         self.write_directory_content(parent, entries);
 
-        let mut entries = self.get_directory_content(new_parent).unwrap();
+        let mut entries = self.get_directory_content(new_parent).map_err(Errno::from_i32)?;
         entries.insert(
             new_name.as_bytes().to_vec(),
             (inode_attrs.inode, inode_attrs.kind),
@@ -1291,22 +1310,21 @@ impl Filesystem for SimpleFS {
         self.write_inode(&inode_attrs);
 
         if inode_attrs.kind == FileKind::Directory {
-            let mut entries = self.get_directory_content(inode_attrs.inode).unwrap();
+            let mut entries = self.get_directory_content(inode_attrs.inode).map_err(Errno::from_i32)?;
             entries.insert(b"..".to_vec(), (new_parent, FileKind::Directory));
             self.write_directory_content(inode_attrs.inode, entries);
         }
 
-        reply.ok();
+        Ok(())
     }
 
     fn link(
         &mut self,
-        req: &Request,
+        req: RequestMeta,
         inode: u64,
         new_parent: u64,
-        new_name: &OsStr,
-        reply: ReplyEntry,
-    ) {
+        new_name: OsString,
+    ) -> Result<Entry, Errno> {
         debug!(
             "link() called for {}, {}, {:?}",
             inode, new_parent, new_name
@@ -1314,28 +1332,30 @@ impl Filesystem for SimpleFS {
         let mut attrs = match self.get_inode(inode) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
         if let Err(error_code) = self.insert_link(req, new_parent, new_name, inode, attrs.kind) {
-            reply.error(error_code);
+            return Err(Errno::from_i32(error_code));
         } else {
             attrs.hardlinks += 1;
             attrs.last_metadata_changed = time_now();
             self.write_inode(&attrs);
-            reply.entry(&Duration::new(0, 0), &attrs.into(), 0);
+            return Ok(Entry{
+                ttl:Duration::new(0, 0), 
+                attr: attrs.into(), 
+                generation: 0,
+            });
         }
     }
 
-    fn open(&mut self, req: &Request, inode: u64, flags: i32, reply: ReplyOpen) {
+    fn open(&mut self, req: RequestMeta, inode: u64, flags: i32) -> Result<Open, Errno> {
         debug!("open() called for {:?}", inode);
         let (access_mask, read, write) = match flags & libc::O_ACCMODE {
             libc::O_RDONLY => {
                 // Behavior is undefined, but most filesystems return EACCES
                 if flags & libc::O_TRUNC != 0 {
-                    reply.error(libc::EACCES);
-                    return;
+                    return Err(Errno::EACCES);
                 }
                 if flags & FMODE_EXEC != 0 {
                     // Open is from internal exec syscall
@@ -1348,8 +1368,7 @@ impl Filesystem for SimpleFS {
             libc::O_RDWR => (libc::R_OK | libc::W_OK, true, true),
             // Exactly one access mode flag must be specified
             _ => {
-                reply.error(libc::EINVAL);
-                return;
+                return Err(Errno::EINVAL);
             }
         };
 
@@ -1359,42 +1378,42 @@ impl Filesystem for SimpleFS {
                     attr.uid,
                     attr.gid,
                     attr.mode,
-                    req.uid(),
-                    req.gid(),
+                    req.uid,
+                    req.gid,
                     access_mask,
                 ) {
                     attr.open_file_handles += 1;
                     self.write_inode(&attr);
                     let open_flags = if self.direct_io { FOPEN_DIRECT_IO } else { 0 };
-                    reply.opened(self.allocate_next_file_handle(read, write), open_flags);
+                    return Ok(Open {
+                        fh: self.allocate_next_file_handle(read, write),
+                        flags: open_flags,
+                    });
                 } else {
-                    reply.error(libc::EACCES);
+                    return Err(Errno::EACCES);
                 }
-                return;
             }
-            Err(error_code) => reply.error(error_code),
+            Err(error_code) => return Err(Errno::from_i32(error_code)),
         }
     }
 
     fn read(
         &mut self,
-        _req: &Request,
+        _req: RequestMeta,
         inode: u64,
         fh: u64,
         offset: i64,
         size: u32,
         _flags: i32,
         _lock_owner: Option<u64>,
-        reply: ReplyData,
-    ) {
+    ) -> Result<Vec<u8>, Errno> {
         debug!(
             "read() called on {:?} offset={:?} size={:?}",
             inode, offset, size
         );
         assert!(offset >= 0);
         if !self.check_file_handle_read(fh) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
         let path = self.content_path(inode);
@@ -1405,35 +1424,33 @@ impl Filesystem for SimpleFS {
 
             let mut buffer = vec![0; read_size as usize];
             file.read_exact_at(&mut buffer, offset as u64).unwrap();
-            reply.data(&buffer);
+            Ok(buffer)
         } else {
-            reply.error(libc::ENOENT);
+            Err(Errno::ENOENT)
         }
     }
 
     fn write(
         &mut self,
-        _req: &Request,
+        _req: RequestMeta,
         inode: u64,
         fh: u64,
         offset: i64,
-        data: &[u8],
+        data: Vec<u8>,
         _write_flags: u32,
         #[allow(unused_variables)] flags: i32,
         _lock_owner: Option<u64>,
-        reply: ReplyWrite,
-    ) {
+    ) -> Result<u32, Errno> {
         debug!("write() called with {:?} size={:?}", inode, data.len());
         assert!(offset >= 0);
         if !self.check_file_handle_write(fh) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
         let path = self.content_path(inode);
         if let Ok(mut file) = OpenOptions::new().write(true).open(path) {
             file.seek(SeekFrom::Start(offset as u64)).unwrap();
-            file.write_all(data).unwrap();
+            file.write_all(&data).unwrap();
 
             let mut attrs = self.get_inode(inode).unwrap();
             attrs.last_metadata_changed = time_now();
@@ -1450,36 +1467,34 @@ impl Filesystem for SimpleFS {
             clear_suid_sgid(&mut attrs);
             self.write_inode(&attrs);
 
-            reply.written(data.len() as u32);
+            Ok(data.len() as u32)
         } else {
-            reply.error(libc::EBADF);
+            Err(Errno::EBADF)
         }
     }
 
     fn release(
         &mut self,
-        _req: &Request<'_>,
+        _req: RequestMeta,
         inode: u64,
         _fh: u64,
         _flags: i32,
         _lock_owner: Option<u64>,
         _flush: bool,
-        reply: ReplyEmpty,
-    ) {
+    ) -> Result<(), Errno> {
         if let Ok(mut attrs) = self.get_inode(inode) {
             attrs.open_file_handles -= 1;
         }
-        reply.ok();
+        Ok(())
     }
 
-    fn opendir(&mut self, req: &Request, inode: u64, flags: i32, reply: ReplyOpen) {
+    fn opendir(&mut self, req: RequestMeta, inode: u64, flags: i32) -> Result<Open, Errno> {
         debug!("opendir() called on {:?}", inode);
         let (access_mask, read, write) = match flags & libc::O_ACCMODE {
             libc::O_RDONLY => {
                 // Behavior is undefined, but most filesystems return EACCES
                 if flags & libc::O_TRUNC != 0 {
-                    reply.error(libc::EACCES);
-                    return;
+                    return Err(Errno::EACCES);
                 }
                 (libc::R_OK, true, false)
             }
@@ -1487,8 +1502,7 @@ impl Filesystem for SimpleFS {
             libc::O_RDWR => (libc::R_OK | libc::W_OK, true, true),
             // Exactly one access mode flag must be specified
             _ => {
-                reply.error(libc::EINVAL);
-                return;
+                return Err(Errno::EINVAL);
             }
         };
 
@@ -1498,147 +1512,140 @@ impl Filesystem for SimpleFS {
                     attr.uid,
                     attr.gid,
                     attr.mode,
-                    req.uid(),
-                    req.gid(),
+                    req.uid,
+                    req.gid,
                     access_mask,
                 ) {
                     attr.open_file_handles += 1;
                     self.write_inode(&attr);
                     let open_flags = if self.direct_io { FOPEN_DIRECT_IO } else { 0 };
-                    reply.opened(self.allocate_next_file_handle(read, write), open_flags);
+                    return Ok(Open {
+                        fh: self.allocate_next_file_handle(read, write),
+                        flags: open_flags,
+                    });
                 } else {
-                    reply.error(libc::EACCES);
+                    return Err(Errno::EACCES);
                 }
-                return;
             }
-            Err(error_code) => reply.error(error_code),
+            Err(error_code) => return Err(Errno::from_i32(error_code)),
         }
     }
 
     fn readdir(
         &mut self,
-        _req: &Request,
+        _req: RequestMeta,
         inode: u64,
         _fh: u64,
         offset: i64,
-        mut reply: ReplyDirectory,
-    ) {
+        _max_bytes: u32
+    ) -> Result<Vec<DirEntry>, Errno> {
         debug!("readdir() called with {:?}", inode);
         assert!(offset >= 0);
         let entries = match self.get_directory_content(inode) {
             Ok(entries) => entries,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
+        let mut result=Vec::new();
 
         for (index, entry) in entries.iter().skip(offset as usize).enumerate() {
             let (name, (inode, file_type)) = entry;
 
-            let buffer_full: bool = reply.add(
-                *inode,
-                offset + index as i64 + 1,
-                (*file_type).into(),
-                OsStr::from_bytes(name),
-            );
-
-            if buffer_full {
-                break;
-            }
+            result.push(DirEntry {
+                ino: *inode,
+                offset: offset + index as i64 + 1,
+                kind: (*file_type).into(),
+                name: OsStr::from_bytes(name).to_owned(),
+            });
+            // TODO stop if bytes > _max_bytes
         }
-
-        reply.ok();
+        Ok(result)
     }
 
     fn releasedir(
         &mut self,
-        _req: &Request<'_>,
+        _req: RequestMeta,
         inode: u64,
         _fh: u64,
         _flags: i32,
-        reply: ReplyEmpty,
-    ) {
+    ) -> Result<(), Errno> {
         if let Ok(mut attrs) = self.get_inode(inode) {
             attrs.open_file_handles -= 1;
         }
-        reply.ok();
+        Ok(())
     }
 
-    fn statfs(&mut self, _req: &Request, _ino: u64, reply: ReplyStatfs) {
+    fn statfs(&mut self, _req: RequestMeta, _ino: u64) -> Result<Statfs, Errno> {
         warn!("statfs() implementation is a stub");
         // TODO: real implementation of this
-        reply.statfs(
-            10_000,
-            10_000,
-            10_000,
-            1,
-            10_000,
-            BLOCK_SIZE as u32,
-            MAX_NAME_LENGTH,
-            BLOCK_SIZE as u32,
-        );
+        Ok(Statfs {
+            blocks: 10_000,
+            bfree: 10_000,
+            bavail: 10_000,
+            files: 1,
+            ffree: 10_000,
+            bsize: BLOCK_SIZE as u32,
+            namelen: MAX_NAME_LENGTH,
+            frsize: BLOCK_SIZE as u32,
+        })
     }
 
     fn setxattr(
         &mut self,
-        request: &Request<'_>,
+        request: RequestMeta,
         inode: u64,
-        key: &OsStr,
-        value: &[u8],
+        key: OsString,
+        value: Vec<u8>,
         _flags: i32,
         _position: u32,
-        reply: ReplyEmpty,
-    ) {
+    ) -> Result<(), Errno> {
         if let Ok(mut attrs) = self.get_inode(inode) {
             if let Err(error) = xattr_access_check(key.as_bytes(), libc::W_OK, &attrs, request) {
-                reply.error(error);
-                return;
+                return Err(Errno::from_i32(error));
             }
 
             attrs.xattrs.insert(key.as_bytes().to_vec(), value.to_vec());
             attrs.last_metadata_changed = time_now();
             self.write_inode(&attrs);
-            reply.ok();
+            Ok(())
         } else {
-            reply.error(libc::EBADF);
+            Err(Errno::EBADF)
         }
     }
 
     fn getxattr(
         &mut self,
-        request: &Request<'_>,
+        request: RequestMeta,
         inode: u64,
-        key: &OsStr,
+        key: OsString,
         size: u32,
-        reply: ReplyXattr,
-    ) {
+    ) -> Result<Xattr, Errno> {
         if let Ok(attrs) = self.get_inode(inode) {
             if let Err(error) = xattr_access_check(key.as_bytes(), libc::R_OK, &attrs, request) {
-                reply.error(error);
-                return;
+                return Err(Errno::from_i32(error));
             }
 
             if let Some(data) = attrs.xattrs.get(key.as_bytes()) {
                 if size == 0 {
-                    reply.size(data.len() as u32);
+                    return Ok(Xattr::Size(data.len() as u32));
                 } else if data.len() <= size as usize {
-                    reply.data(data);
+                    return Ok(Xattr::Data(data.to_owned()));
                 } else {
-                    reply.error(libc::ERANGE);
+                    return Err(Errno::ERANGE);
                 }
             } else {
                 #[cfg(target_os = "linux")]
-                reply.error(libc::ENODATA);
+                return Err(Errno::ENODATA);
                 #[cfg(not(target_os = "linux"))]
-                reply.error(libc::ENOATTR);
+                return Err(Errno::ENOATTR);
             }
         } else {
-            reply.error(libc::EBADF);
+            Err(Errno::EBADF)
         }
     }
 
-    fn listxattr(&mut self, _req: &Request<'_>, inode: u64, size: u32, reply: ReplyXattr) {
+    fn listxattr(&mut self, _req: RequestMeta, inode: u64, size: u32) -> Result<Xattr, Errno> {
         if let Ok(attrs) = self.get_inode(inode) {
             let mut bytes = vec![];
             // Convert to concatenated null-terminated strings
@@ -1647,67 +1654,63 @@ impl Filesystem for SimpleFS {
                 bytes.push(0);
             }
             if size == 0 {
-                reply.size(bytes.len() as u32);
+                return Ok(Xattr::Size(bytes.len() as u32));
             } else if bytes.len() <= size as usize {
-                reply.data(&bytes);
+                return Ok(Xattr::Data(bytes));
             } else {
-                reply.error(libc::ERANGE);
+                return Err(Errno::ERANGE);
             }
         } else {
-            reply.error(libc::EBADF);
+            Err(Errno::EBADF)
         }
     }
 
-    fn removexattr(&mut self, request: &Request<'_>, inode: u64, key: &OsStr, reply: ReplyEmpty) {
+    fn removexattr(&mut self, request: RequestMeta, inode: u64, key: OsString) -> Result<(), Errno> {
         if let Ok(mut attrs) = self.get_inode(inode) {
             if let Err(error) = xattr_access_check(key.as_bytes(), libc::W_OK, &attrs, request) {
-                reply.error(error);
-                return;
+                return Err(Errno::from_i32(error));
             }
 
             if attrs.xattrs.remove(key.as_bytes()).is_none() {
                 #[cfg(target_os = "linux")]
-                reply.error(libc::ENODATA);
+                return Err(Errno::ENODATA);
                 #[cfg(not(target_os = "linux"))]
-                reply.error(libc::ENOATTR);
-                return;
+                return Err(Errno::ENOATTR);
             }
             attrs.last_metadata_changed = time_now();
             self.write_inode(&attrs);
-            reply.ok();
+            Ok(())
         } else {
-            reply.error(libc::EBADF);
+            Err(Errno::EBADF)
         }
     }
 
-    fn access(&mut self, req: &Request, inode: u64, mask: i32, reply: ReplyEmpty) {
+    fn access(&mut self, req: RequestMeta, inode: u64, mask: i32) -> Result<(), Errno> {
         debug!("access() called with {:?} {:?}", inode, mask);
         match self.get_inode(inode) {
             Ok(attr) => {
-                if check_access(attr.uid, attr.gid, attr.mode, req.uid(), req.gid(), mask) {
-                    reply.ok();
+                if check_access(attr.uid, attr.gid, attr.mode, req.uid, req.gid, mask) {
+                    return Ok(());
                 } else {
-                    reply.error(libc::EACCES);
+                    Err(Errno::EACCES)
                 }
             }
-            Err(error_code) => reply.error(error_code),
+            Err(error_code) => Err(Errno::from_i32(error_code)),
         }
     }
 
     fn create(
         &mut self,
-        req: &Request,
+        req: RequestMeta,
         parent: u64,
-        name: &OsStr,
+        name: OsString,
         mut mode: u32,
         _umask: u32,
         flags: i32,
-        reply: ReplyCreate,
-    ) {
+    ) -> Result<(Entry, Open), Errno> {
         debug!("create() called with {:?} {:?}", parent, name);
-        if self.lookup_name(parent, name).is_ok() {
-            reply.error(libc::EEXIST);
-            return;
+        if self.lookup_name(parent, &name).is_ok() {
+            return Err(Errno::EEXIST);
         }
 
         let (read, write) = match flags & libc::O_ACCMODE {
@@ -1716,16 +1719,14 @@ impl Filesystem for SimpleFS {
             libc::O_RDWR => (true, true),
             // Exactly one access mode flag must be specified
             _ => {
-                reply.error(libc::EINVAL);
-                return;
+                return Err(Errno::EINVAL);
             }
         };
 
         let mut parent_attrs = match self.get_inode(parent) {
             Ok(attrs) => attrs,
             Err(error_code) => {
-                reply.error(error_code);
-                return;
+                return Err(Errno::from_i32(error_code));
             }
         };
 
@@ -1733,18 +1734,17 @@ impl Filesystem for SimpleFS {
             parent_attrs.uid,
             parent_attrs.gid,
             parent_attrs.mode,
-            req.uid(),
-            req.gid(),
+            req.uid,
+            req.gid,
             libc::W_OK,
         ) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
         parent_attrs.last_modified = time_now();
         parent_attrs.last_metadata_changed = time_now();
         self.write_inode(&parent_attrs);
 
-        if req.uid() != 0 {
+        if req.uid != 0 {
             mode &= !(libc::S_ISUID | libc::S_ISGID) as u32;
         }
 
@@ -1759,8 +1759,8 @@ impl Filesystem for SimpleFS {
             kind: as_file_kind(mode),
             mode: self.creation_mode(mode),
             hardlinks: 1,
-            uid: req.uid(),
-            gid: creation_gid(&parent_attrs, req.gid()),
+            uid: req.uid,
+            gid: creation_gid(&parent_attrs, req.gid),
             xattrs: Default::default(),
         };
         self.write_inode(&attrs);
@@ -1778,26 +1778,29 @@ impl Filesystem for SimpleFS {
         self.write_directory_content(parent, entries);
 
         // TODO: implement flags
-        reply.created(
-            &Duration::new(0, 0),
-            &attrs.into(),
-            0,
-            self.allocate_next_file_handle(read, write),
-            0,
-        );
+        return Ok(( 
+            Entry {
+                attr: attrs.into(),
+                ttl: Duration::new(0, 0),
+                generation: 0,
+            }, 
+            Open {
+                fh: self.allocate_next_file_handle(read, write),
+                flags: 0,
+            }
+        ));
     }
 
     #[cfg(target_os = "linux")]
     fn fallocate(
         &mut self,
-        _req: &Request<'_>,
+        _req: RequestMeta,
         inode: u64,
         _fh: u64,
         offset: i64,
         length: i64,
         mode: i32,
-        reply: ReplyEmpty,
-    ) {
+    ) -> Result<(), Errno> {
         let path = self.content_path(inode);
         if let Ok(file) = OpenOptions::new().write(true).open(path) {
             unsafe {
@@ -1812,15 +1815,15 @@ impl Filesystem for SimpleFS {
                 }
                 self.write_inode(&attrs);
             }
-            reply.ok();
+            Ok(())
         } else {
-            reply.error(libc::ENOENT);
+            Err(Errno::ENOENT)
         }
     }
 
     fn copy_file_range(
         &mut self,
-        _req: &Request<'_>,
+        _req: RequestMeta,
         src_inode: u64,
         src_fh: u64,
         src_offset: i64,
@@ -1829,19 +1832,16 @@ impl Filesystem for SimpleFS {
         dest_offset: i64,
         size: u64,
         _flags: u32,
-        reply: ReplyWrite,
-    ) {
+    ) -> Result<u32, Errno> {
         debug!(
             "copy_file_range() called with src ({}, {}, {}) dest ({}, {}, {}) size={}",
             src_fh, src_inode, src_offset, dest_fh, dest_inode, dest_offset, size
         );
         if !self.check_file_handle_read(src_fh) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
         if !self.check_file_handle_write(dest_fh) {
-            reply.error(libc::EACCES);
-            return;
+            return Err(Errno::EACCES);
         }
 
         let src_path = self.content_path(src_inode);
@@ -1866,12 +1866,12 @@ impl Filesystem for SimpleFS {
                 }
                 self.write_inode(&attrs);
 
-                reply.written(data.len() as u32);
+                return Ok(data.len() as u32);
             } else {
-                reply.error(libc::EBADF);
+                return Err(Errno::EBADF);
             }
         } else {
-            reply.error(libc::ENOENT);
+            return Err(Errno::ENOENT);
         }
     }
 }
@@ -1992,6 +1992,12 @@ fn main() {
                 .help("Enable setuid support when run as root"),
         )
         .arg(
+            Arg::new("user")
+                .long("user")
+                .action(ArgAction::SetTrue)
+                .help("disable root-priviledge features"),
+        )
+        .arg(
             Arg::new("v")
                 .short('v')
                 .action(ArgAction::Count)
@@ -2014,25 +2020,27 @@ fn main() {
 
     let mut options = vec![MountOption::FSName("fuser".to_string())];
 
-    #[cfg(feature = "abi-7-26")]
-    {
-        if matches.get_flag("suid") {
-            info!("setuid bit support enabled");
-            options.push(MountOption::Suid);
-        } else {
+    if !matches.get_flag("user"){
+        #[cfg(feature = "abi-7-26")]
+        {
+            if matches.get_flag("suid") {
+                info!("setuid bit support enabled");
+                options.push(MountOption::Suid);
+            } else {
+                options.push(MountOption::AutoUnmount);
+            }
+        }
+        #[cfg(not(feature = "abi-7-26"))]
+        {
             options.push(MountOption::AutoUnmount);
         }
-    }
-    #[cfg(not(feature = "abi-7-26"))]
-    {
-        options.push(MountOption::AutoUnmount);
-    }
-    if let Ok(enabled) = fuse_allow_other_enabled() {
-        if enabled {
-            options.push(MountOption::AllowOther);
+        if let Ok(enabled) = fuse_allow_other_enabled() {
+            if enabled {
+                options.push(MountOption::AllowOther);
+            }
+        } else {
+            eprintln!("Unable to read /etc/fuse.conf");
         }
-    } else {
-        eprintln!("Unable to read /etc/fuse.conf");
     }
 
     let data_dir = matches.get_one::<String>("data-dir").unwrap().to_string();
@@ -2047,6 +2055,7 @@ fn main() {
             data_dir,
             matches.get_flag("direct-io"),
             matches.get_flag("suid"),
+            matches.get_flag("user")
         ),
         mountpoint,
         &options,
@@ -2055,7 +2064,7 @@ fn main() {
         // Return a special error code for permission denied, which usually indicates that
         // "user_allow_other" is missing from /etc/fuse.conf
         if e.kind() == ErrorKind::PermissionDenied {
-            error!("{}", e.to_string());
+            error!("{}", e);
             std::process::exit(2);
         }
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -16,7 +16,7 @@ use crate::reply::ReplySender;
 
 /// A raw communication channel to the FUSE kernel driver
 #[derive(Debug)]
-pub struct Channel(Arc<File>);
+pub(crate) struct Channel(Arc<File>);
 
 impl AsFd for Channel {
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -33,7 +33,7 @@ impl Channel {
     }
 
     /// Receives data up to the capacity of the given buffer (can block).
-    pub fn receive(&self, buffer: &mut [u8]) -> io::Result<usize> {
+    pub(crate) fn receive(&self, buffer: &mut [u8]) -> io::Result<usize> {
         let rc = unsafe {
             libc::read(
                 self.0.as_raw_fd(),
@@ -51,7 +51,7 @@ impl Channel {
     /// Returns a sender object for this channel. The sender object can be
     /// used to send to the channel. Multiple sender objects can be used
     /// and they can safely be sent to other threads.
-    pub fn sender(&self) -> ChannelSender {
+    pub(crate) fn sender(&self) -> ChannelSender {
         // Since write/writev syscalls are threadsafe, we can simply create
         // a sender by using the same file and use it in other threads.
         ChannelSender(self.0.clone())
@@ -59,7 +59,7 @@ impl Channel {
 }
 
 #[derive(Clone, Debug)]
-pub struct ChannelSender(Arc<File>);
+pub(crate) struct ChannelSender(Arc<File>);
 
 impl ReplySender for ChannelSender {
     fn send(&self, bufs: &[io::IoSlice<'_>]) -> io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,13 @@
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
-use libc::{c_int, ENOSYS, EPERM};
 use log::warn;
 use mnt::mount_options::parse_options_from_args;
 #[cfg(feature = "serializable")]
 use serde::{Deserialize, Serialize};
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 #[cfg(feature = "abi-7-23")]
 use std::time::Duration;
 use std::time::SystemTime;
@@ -24,24 +23,18 @@ pub use crate::ll::fuse_abi::FUSE_ROOT_ID;
 pub use crate::ll::{fuse_abi::consts, TimeOrNow};
 use crate::mnt::mount_options::check_option_conflicts;
 use crate::session::MAX_WRITE_SIZE;
-#[cfg(feature = "abi-7-16")]
-pub use ll::fuse_abi::fuse_forget_one;
 pub use mnt::mount_options::MountOption;
 #[cfg(feature = "abi-7-11")]
 pub use notify::{Notifier, PollHandle};
+#[cfg(feature = "abi-7-11")]
+pub use reply::Ioctl;
 #[cfg(feature = "abi-7-40")]
 pub use passthrough::BackingId;
-#[cfg(feature = "abi-7-11")]
-pub use reply::ReplyPoll;
 #[cfg(target_os = "macos")]
-pub use reply::ReplyXTimes;
-pub use reply::ReplyXattr;
-pub use reply::{Reply, ReplyAttr, ReplyData, ReplyEmpty, ReplyEntry, ReplyOpen};
-pub use reply::{
-    ReplyBmap, ReplyCreate, ReplyDirectory, ReplyDirectoryPlus, ReplyIoctl, ReplyLock, ReplyLseek,
-    ReplyStatfs, ReplyWrite,
-};
-pub use request::Request;
+pub use reply::XTimes;
+pub use reply::{Entry, Attr, DirEntry, Open, Statfs, Xattr, Lock};
+pub use ll::Errno;
+pub use request::RequestMeta;
 pub use session::{BackgroundSession, Session, SessionACL, SessionUnmounter};
 #[cfg(feature = "abi-7-28")]
 use std::cmp::max;
@@ -72,7 +65,8 @@ const INIT_FLAGS: u64 = FUSE_ASYNC_READ | FUSE_BIG_WRITES;
 const INIT_FLAGS: u64 = FUSE_ASYNC_READ | FUSE_CASE_INSENSITIVE | FUSE_VOL_RENAME | FUSE_XTIMES;
 // TODO: Add FUSE_EXPORT_SUPPORT and FUSE_BIG_WRITES (requires ABI 7.10)
 
-const fn default_init_flags(#[allow(unused_variables)] capabilities: u64) -> u64 {
+#[allow(unused_variables)]
+const fn default_init_flags(capabilities: u64) -> u64 {
     #[cfg(not(feature = "abi-7-28"))]
     {
         INIT_FLAGS
@@ -142,6 +136,17 @@ pub struct FileAttr {
     pub blksize: u32,
     /// Flags (macOS only, see chflags(2))
     pub flags: u32,
+}
+
+#[derive(Debug)]
+/// Target of a `forget` or `batch_forget` operation.
+pub struct Forget {
+    /// Inode of the file to be forgotten.
+    pub ino: u64,
+    /// The number of times the file has been looked up (and not yet forgotten).
+    /// When a `forget` operation is received, the filesystem should typically
+    /// decrement its internal reference count for the inode by `nlookup`.
+    pub nlookup: u64
 }
 
 /// Configuration of the fuse kernel module connection
@@ -325,12 +330,14 @@ impl KernelConfig {
 /// implementations are provided here to get a mountable filesystem that does
 /// nothing.
 #[allow(clippy::too_many_arguments)]
+#[allow(unused_variables)] // This is the main API, so variables are named without the underscore even though the defaults may not use them.
 pub trait Filesystem {
     /// Initialize filesystem.
     /// Called before any other filesystem method.
-    /// The kernel module connection can be configured using the KernelConfig object
-    fn init(&mut self, _req: &Request<'_>, _config: &mut KernelConfig) -> Result<(), c_int> {
-        Ok(())
+    /// The kernel module connection can be configured using the KernelConfig object.
+    /// The method should return `Ok(KernelConfig)` to accept the connection, or `Err(Errno)` to reject it.
+    fn init(&mut self, req: RequestMeta, config: KernelConfig) -> Result<KernelConfig, Errno> {
+        Ok(config)
     }
 
     /// Clean up filesystem.
@@ -338,245 +345,253 @@ pub trait Filesystem {
     fn destroy(&mut self) {}
 
     /// Look up a directory entry by name and get its attributes.
-    fn lookup(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEntry) {
+    /// The method should return `Ok(Entry)` if the entry is found, or `Err(Errno)` otherwise.
+    fn lookup(&mut self, req: RequestMeta, parent: u64, name: OsString) -> Result<Entry, Errno> {
         warn!(
             "[Not Implemented] lookup(parent: {:#x?}, name {:?})",
             parent, name
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Forget about an inode.
-    /// The nlookup parameter indicates the number of lookups previously performed on
+    /// The `target.nlookup` parameter indicates the number of lookups previously performed on
     /// this inode. If the filesystem implements inode lifetimes, it is recommended that
-    /// inodes acquire a single reference on each lookup, and lose nlookup references on
+    /// inodes acquire a single reference on each lookup, and lose `target.nlookup` references on
     /// each forget. The filesystem may ignore forget calls, if the inodes don't need to
     /// have a limited lifetime. On unmount it is not guaranteed, that all referenced
-    /// inodes will receive a forget message.
-    fn forget(&mut self, _req: &Request<'_>, _ino: u64, _nlookup: u64) {}
+    /// inodes will receive a forget message. This operation does not return a result.
+    fn forget(&mut self, req: RequestMeta, target: Forget) {}
 
     /// Like forget, but take multiple forget requests at once for performance. The default
-    /// implementation will fallback to forget.
+    /// implementation will fallback to `forget` for each node. This operation does not return a result.
     #[cfg(feature = "abi-7-16")]
-    fn batch_forget(&mut self, req: &Request<'_>, nodes: &[fuse_forget_one]) {
+    fn batch_forget(&mut self, req: RequestMeta, nodes: Vec<Forget>) {
         for node in nodes {
-            self.forget(req, node.nodeid, node.nlookup);
+            self.forget(req, node);
         }
     }
 
     /// Get file attributes.
-    fn getattr(&mut self, _req: &Request<'_>, ino: u64, fh: Option<u64>, reply: ReplyAttr) {
+    /// The method should return `Ok(Attr)` with the file attributes, or `Err(Errno)` otherwise.
+    fn getattr(&mut self, req: RequestMeta, ino: u64, fh: Option<u64>) -> Result<Attr, Errno> {
         warn!(
             "[Not Implemented] getattr(ino: {:#x?}, fh: {:#x?})",
             ino, fh
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Set file attributes.
+    /// The method should return `Ok(Attr)` with the updated file attributes, or `Err(Errno)` otherwise.
     fn setattr(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         mode: Option<u32>,
         uid: Option<u32>,
         gid: Option<u32>,
         size: Option<u64>,
-        _atime: Option<TimeOrNow>,
-        _mtime: Option<TimeOrNow>,
-        _ctime: Option<SystemTime>,
+        atime: Option<TimeOrNow>,
+        mtime: Option<TimeOrNow>,
+        ctime: Option<SystemTime>,
         fh: Option<u64>,
-        _crtime: Option<SystemTime>,
-        _chgtime: Option<SystemTime>,
-        _bkuptime: Option<SystemTime>,
-        flags: Option<u32>,
-        reply: ReplyAttr,
-    ) {
+        crtime: Option<SystemTime>,
+        chgtime: Option<SystemTime>,
+        bkuptime: Option<SystemTime>,
+        flags: Option<u32>
+    ) -> Result<Attr, Errno> {
         warn!(
             "[Not Implemented] setattr(ino: {:#x?}, mode: {:?}, uid: {:?}, \
             gid: {:?}, size: {:?}, fh: {:?}, flags: {:?})",
             ino, mode, uid, gid, size, fh, flags
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Read symbolic link.
-    fn readlink(&mut self, _req: &Request<'_>, ino: u64, reply: ReplyData) {
+    /// The method should return `Ok(Vec<u8>)` with the link target, or `Err(Errno)` otherwise.
+    fn readlink(&mut self, req: RequestMeta, ino: u64) -> Result<Vec<u8>, Errno> {
         warn!("[Not Implemented] readlink(ino: {:#x?})", ino);
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Create file node.
     /// Create a regular file, character device, block device, fifo or socket node.
+    /// The method should return `Ok(Entry)` with the new entry's attributes, or `Err(Errno)` otherwise.
     fn mknod(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         parent: u64,
-        name: &OsStr,
+        name: OsString,
         mode: u32,
         umask: u32,
         rdev: u32,
-        reply: ReplyEntry,
-    ) {
+    ) -> Result<Entry, Errno> {
         warn!(
             "[Not Implemented] mknod(parent: {:#x?}, name: {:?}, mode: {}, \
             umask: {:#x?}, rdev: {})",
             parent, name, mode, umask, rdev
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Create a directory.
+    /// The method should return `Ok(Entry)` with the new directory's attributes, or `Err(Errno)` otherwise.
     fn mkdir(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         parent: u64,
-        name: &OsStr,
+        name: OsString,
         mode: u32,
         umask: u32,
-        reply: ReplyEntry,
-    ) {
+    ) -> Result<Entry, Errno> {
         warn!(
             "[Not Implemented] mkdir(parent: {:#x?}, name: {:?}, mode: {}, umask: {:#x?})",
             parent, name, mode, umask
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Remove a file.
-    fn unlink(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEmpty) {
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
+    fn unlink(&mut self, req: RequestMeta, parent: u64, name: OsString) -> Result<(), Errno> {
         warn!(
             "[Not Implemented] unlink(parent: {:#x?}, name: {:?})",
             parent, name,
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Remove a directory.
-    fn rmdir(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEmpty) {
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
+    fn rmdir(&mut self, req: RequestMeta, parent: u64, name: OsString) -> Result<(), Errno> {
         warn!(
             "[Not Implemented] rmdir(parent: {:#x?}, name: {:?})",
             parent, name,
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Create a symbolic link.
+    /// The method should return `Ok(Entry)` with the new link's attributes, or `Err(Errno)` otherwise.
     fn symlink(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         parent: u64,
-        link_name: &OsStr,
-        target: &Path,
-        reply: ReplyEntry,
-    ) {
+        link_name: OsString,
+        target: PathBuf,
+    ) -> Result<Entry, Errno> {
         warn!(
             "[Not Implemented] symlink(parent: {:#x?}, link_name: {:?}, target: {:?})",
             parent, link_name, target,
         );
-        reply.error(EPERM);
+        Err(Errno::EPERM) // why isn't this ENOSYS?
     }
 
     /// Rename a file.
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
+    /// `flags` may be `RENAME_EXCHANGE` or `RENAME_NOREPLACE`.
     fn rename(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         parent: u64,
-        name: &OsStr,
+        name: OsString,
         newparent: u64,
-        newname: &OsStr,
+        newname: OsString,
         flags: u32,
-        reply: ReplyEmpty,
-    ) {
+    ) -> Result<(), Errno> {
         warn!(
             "[Not Implemented] rename(parent: {:#x?}, name: {:?}, newparent: {:#x?}, \
             newname: {:?}, flags: {})",
             parent, name, newparent, newname, flags,
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Create a hard link.
+    /// The method should return `Ok(Entry)` with the new link's attributes, or `Err(Errno)` otherwise.
     fn link(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         newparent: u64,
-        newname: &OsStr,
-        reply: ReplyEntry,
-    ) {
+        newname: OsString,
+    ) -> Result<Entry, Errno> {
         warn!(
             "[Not Implemented] link(ino: {:#x?}, newparent: {:#x?}, newname: {:?})",
             ino, newparent, newname
         );
-        reply.error(EPERM);
+        Err(Errno::EPERM) // why isn't this ENOSYS?
     }
 
     /// Open a file.
     /// Open flags (with the exception of O_CREAT, O_EXCL, O_NOCTTY and O_TRUNC) are
-    /// available in flags. Filesystem may store an arbitrary file handle (pointer, index,
-    /// etc) in fh, and use this in other all other file operations (read, write, flush,
+    /// available in `flags`. Filesystem may store an arbitrary file handle (pointer, index,
+    /// etc) in `Open.fh`, and use this in other all other file operations (read, write, flush,
     /// release, fsync). Filesystem may also implement stateless file I/O and not store
-    /// anything in fh. There are also some flags (direct_io, keep_cache) which the
-    /// filesystem may set, to change the way the file is opened. See fuse_file_info
-    /// structure in <fuse_common.h> for more details.
-    fn open(&mut self, _req: &Request<'_>, _ino: u64, _flags: i32, reply: ReplyOpen) {
-        reply.opened(0, 0);
+    /// anything in `Open.fh`. There are also some flags (direct_io, keep_cache) which the
+    /// filesystem may set in `Open.flags`, to change the way the file is opened. See fuse_file_info
+    /// structure in `<fuse_common.h>` for more details.
+    /// The method should return `Ok(Open)` on success, or `Err(Errno)` otherwise.
+    fn open(&mut self, req: RequestMeta, ino: u64, flags: i32) -> Result<Open, Errno> {
+        warn!("[Not Implemented] open(ino: {:#x?}, flags: {})", ino, flags);
+        Err(Errno::ENOSYS)
     }
 
     /// Read data.
-    /// Read should send exactly the number of bytes requested except on EOF or error,
+    /// Read should return exactly the number of bytes requested except on EOF or error,
     /// otherwise the rest of the data will be substituted with zeroes. An exception to
     /// this is when the file has been opened in 'direct_io' mode, in which case the
     /// return value of the read system call will reflect the return value of this
-    /// operation. fh will contain the value set by the open method, or will be undefined
+    /// operation. `fh` will contain the value set by the open method, or will be undefined
     /// if the open method didn't set any value.
+    /// The method should return `Ok(Vec<u8>)` with the read data, or `Err(Errno)` otherwise.
     ///
-    /// flags: these are the file flags, such as O_SYNC. Only supported with ABI >= 7.9
-    /// lock_owner: only supported with ABI >= 7.9
+    /// `flags`: these are the file flags, such as O_SYNC. Only supported with ABI >= 7.9
+    /// `lock_owner`: only supported with ABI >= 7.9
     fn read(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         fh: u64,
         offset: i64,
         size: u32,
         flags: i32,
         lock_owner: Option<u64>,
-        reply: ReplyData,
-    ) {
+    ) -> Result<Vec<u8>, Errno> {
         warn!(
             "[Not Implemented] read(ino: {:#x?}, fh: {}, offset: {}, size: {}, \
             flags: {:#x?}, lock_owner: {:?})",
             ino, fh, offset, size, flags, lock_owner
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Write data.
     /// Write should return exactly the number of bytes requested except on error. An
     /// exception to this is when the file has been opened in 'direct_io' mode, in
     /// which case the return value of the write system call will reflect the return
-    /// value of this operation. fh will contain the value set by the open method, or
+    /// value of this operation. `fh` will contain the value set by the open method, or
     /// will be undefined if the open method didn't set any value.
+    /// The method should return `Ok(u32)` with the number of bytes written, or `Err(Errno)` otherwise.
     ///
-    /// write_flags: will contain FUSE_WRITE_CACHE, if this write is from the page cache. If set,
-    /// the pid, uid, gid, and fh may not match the value that would have been sent if write cachin
-    /// is disabled
-    /// flags: these are the file flags, such as O_SYNC. Only supported with ABI >= 7.9
-    /// lock_owner: only supported with ABI >= 7.9
+    /// `write_flags`: will contain `FUSE_WRITE_CACHE`, if this write is from the page cache. If set,
+    /// the pid, uid, gid, and fh may not match the value that would have been sent if write caching
+    /// is disabled.
+    /// `flags`: these are the file flags, such as O_SYNC. Only supported with ABI >= 7.9.
+    /// `lock_owner`: only supported with ABI >= 7.9.
     fn write(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         fh: u64,
         offset: i64,
-        data: &[u8],
+        data: Vec<u8>,
         write_flags: u32,
         flags: i32,
         lock_owner: Option<u64>,
-        reply: ReplyWrite,
-    ) {
+    ) -> Result<u32, Errno> {
         warn!(
             "[Not Implemented] write(ino: {:#x?}, fh: {}, offset: {}, data.len(): {}, \
             write_flags: {:#x?}, flags: {:#x?}, lock_owner: {:?})",
@@ -588,248 +603,274 @@ pub trait Filesystem {
             flags,
             lock_owner
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Flush method.
-    /// This is called on each close() of the opened file. Since file descriptors can
+    /// This is called on each `close()` of the opened file. Since file descriptors can
     /// be duplicated (dup, dup2, fork), for one open call there may be many flush
     /// calls. Filesystems shouldn't assume that flush will always be called after some
-    /// writes, or that if will be called at all. fh will contain the value set by the
+    /// writes, or that it will be called at all. `fh` will contain the value set by the
     /// open method, or will be undefined if the open method didn't set any value.
     /// NOTE: the name of the method is misleading, since (unlike fsync) the filesystem
-    /// is not forced to flush pending writes. One reason to flush data, is if the
+    /// is not forced to flush pending writes. One reason to flush data is if the
     /// filesystem wants to return write errors. If the filesystem supports file locking
-    /// operations (setlk, getlk) it should remove all locks belonging to 'lock_owner'.
-    fn flush(&mut self, _req: &Request<'_>, ino: u64, fh: u64, lock_owner: u64, reply: ReplyEmpty) {
+    /// operations (setlk, getlk) it should remove all locks belonging to `lock_owner`.
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
+    fn flush(&mut self, req: RequestMeta, ino: u64, fh: u64, lock_owner: u64) -> Result<(), Errno> {
         warn!(
             "[Not Implemented] flush(ino: {:#x?}, fh: {}, lock_owner: {:?})",
             ino, fh, lock_owner
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Release an open file.
     /// Release is called when there are no more references to an open file: all file
     /// descriptors are closed and all memory mappings are unmapped. For every open
-    /// call there will be exactly one release call. The filesystem may reply with an
-    /// error, but error values are not returned to close() or munmap() which triggered
-    /// the release. fh will contain the value set by the open method, or will be undefined
-    /// if the open method didn't set any value. flags will contain the same flags as for
+    /// call there will be exactly one release call. The filesystem may return an
+    /// error, but error values are not returned to `close()` or `munmap()` which triggered
+    /// the release. `fh` will contain the value set by the open method, or will be undefined
+    /// if the open method didn't set any value. `flags` will contain the same flags as for
     /// open.
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
     fn release(
         &mut self,
-        _req: &Request<'_>,
-        _ino: u64,
-        _fh: u64,
-        _flags: i32,
-        _lock_owner: Option<u64>,
-        _flush: bool,
-        reply: ReplyEmpty,
-    ) {
-        reply.ok();
+        req: RequestMeta,
+        ino: u64,
+        fh: u64,
+        flags: i32,
+        lock_owner: Option<u64>,
+        flush: bool,
+    ) -> Result<(), Errno> {
+        Ok(())
     }
 
     /// Synchronize file contents.
-    /// If the datasync parameter is non-zero, then only the user data should be flushed,
+    /// If the `datasync` parameter is non-zero, then only the user data should be flushed,
     /// not the meta data.
-    fn fsync(&mut self, _req: &Request<'_>, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
+    fn fsync(&mut self, req: RequestMeta, ino: u64, fh: u64, datasync: bool) -> Result<(), Errno> {
         warn!(
             "[Not Implemented] fsync(ino: {:#x?}, fh: {}, datasync: {})",
             ino, fh, datasync
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Open a directory.
-    /// Filesystem may store an arbitrary file handle (pointer, index, etc) in fh, and
+    /// Filesystem may store an arbitrary file handle (pointer, index, etc) in `Open.fh`, and
     /// use this in other all other directory stream operations (readdir, releasedir,
     /// fsyncdir). Filesystem may also implement stateless directory I/O and not store
-    /// anything in fh, though that makes it impossible to implement standard conforming
+    /// anything in `Open.fh`, though that makes it impossible to implement standard conforming
     /// directory stream operations in case the contents of the directory can change
     /// between opendir and releasedir.
-    fn opendir(&mut self, _req: &Request<'_>, _ino: u64, _flags: i32, reply: ReplyOpen) {
-        reply.opened(0, 0);
+    /// The method should return `Ok(Open)` on success, or `Err(Errno)` otherwise.
+    fn opendir(&mut self, req: RequestMeta, ino: u64, flags: i32) -> Result<Open, Errno> {
+        warn!("[Not Implemented] open(ino: {:#x?}, flags: {})", ino, flags);
+        Err(Errno::ENOSYS)
+        // TODO: Open{0,0}
     }
 
     /// Read directory.
-    /// Send a buffer filled using buffer.fill(), with size not exceeding the
-    /// requested size. Send an empty buffer on end of stream. fh will contain the
-    /// value set by the opendir method, or will be undefined if the opendir method
-    /// didn't set any value.
+    /// The filesystem should return a buffer filled with directory entries. The buffer
+    /// must not exceed the `max_bytes` parameter. An empty buffer indicates the end of
+    /// the stream. `fh` will contain the value set by the opendir method, or will be
+    /// undefined if the opendir method didn't set any value.
+    /// The method should return `Ok(Vec<DirEntry>)` with the directory entries, or `Err(Errno)` otherwise.
     fn readdir(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         fh: u64,
         offset: i64,
-        reply: ReplyDirectory,
-    ) {
+        max_bytes: u32
+    ) -> Result<Vec<DirEntry>, Errno> {
         warn!(
-            "[Not Implemented] readdir(ino: {:#x?}, fh: {}, offset: {})",
-            ino, fh, offset
+            "[Not Implemented] readdir(ino: {:#x?}, fh: {}, offset: {}, max_bytes: {})",
+            ino, fh, offset, max_bytes
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Read directory.
-    /// Send a buffer filled using buffer.fill(), with size not exceeding the
-    /// requested size. Send an empty buffer on end of stream. fh will contain the
-    /// value set by the opendir method, or will be undefined if the opendir method
-    /// didn't set any value.
+    /// Similar to `readdir`, but also returns the attributes of each directory entry.
+    /// The filesystem should return a buffer filled with directory entries and their attributes.
+    /// The buffer must not exceed the `max_bytes` parameter. An empty buffer indicates the end of
+    /// the stream. `fh` will contain the value set by the opendir method, or will be
+    /// undefined if the opendir method didn't set any value.
+    /// The method should return `Ok(Vec<(DirEntry, Entry)>)` with the directory entries and their attributes, or `Err(Errno)` otherwise.
+    #[cfg(feature = "abi-7-21")]
     fn readdirplus(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         fh: u64,
         offset: i64,
-        reply: ReplyDirectoryPlus,
-    ) {
+        max_bytes: u32,
+    ) -> Result<Vec<(DirEntry, Entry)>, Errno>{
         warn!(
-            "[Not Implemented] readdirplus(ino: {:#x?}, fh: {}, offset: {})",
-            ino, fh, offset
+            "[Not Implemented] readdirplus(ino: {:#x?}, fh: {}, offset: {}, max_bytes: {})",
+            ino, fh, offset, max_bytes
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Release an open directory.
-    /// For every opendir call there will be exactly one releasedir call. fh will
+    /// For every opendir call there will be exactly one releasedir call. `fh` will
     /// contain the value set by the opendir method, or will be undefined if the
     /// opendir method didn't set any value.
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
     fn releasedir(
         &mut self,
-        _req: &Request<'_>,
-        _ino: u64,
-        _fh: u64,
-        _flags: i32,
-        reply: ReplyEmpty,
-    ) {
-        reply.ok();
+        req: RequestMeta,
+        ino: u64,
+        fh: u64,
+        flags: i32,
+    ) -> Result<(), Errno> {
+        Ok(())
     }
 
     /// Synchronize directory contents.
-    /// If the datasync parameter is set, then only the directory contents should
-    /// be flushed, not the meta data. fh will contain the value set by the opendir
+    /// If the `datasync` parameter is set, then only the directory contents should
+    /// be flushed, not the meta data. `fh` will contain the value set by the opendir
     /// method, or will be undefined if the opendir method didn't set any value.
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
     fn fsyncdir(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         fh: u64,
         datasync: bool,
-        reply: ReplyEmpty,
-    ) {
+    ) -> Result<(), Errno> {
         warn!(
             "[Not Implemented] fsyncdir(ino: {:#x?}, fh: {}, datasync: {})",
             ino, fh, datasync
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Get file system statistics.
-    fn statfs(&mut self, _req: &Request<'_>, _ino: u64, reply: ReplyStatfs) {
-        reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);
+    /// The method should return `Ok(Statfs)` with the filesystem statistics, or `Err(Errno)` otherwise.
+    fn statfs(&mut self, req: RequestMeta, ino: u64) -> Result<Statfs, Errno> {
+        warn!("[Not Implemented] statfs(ino: {:#x?})", ino);
+        Err(Errno::ENOSYS)
+        // TODO: Statfs{0, 0, 0, 0, 0, 512, 255, 0}
     }
 
     /// Set an extended attribute.
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
     fn setxattr(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
-        name: &OsStr,
-        _value: &[u8],
+        name: OsString,
+        value: Vec<u8>, 
         flags: i32,
         position: u32,
-        reply: ReplyEmpty,
-    ) {
+    ) -> Result<(), Errno> {
         warn!(
             "[Not Implemented] setxattr(ino: {:#x?}, name: {:?}, flags: {:#x?}, position: {})",
             ino, name, flags, position
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Get an extended attribute.
-    /// If `size` is 0, the size of the value should be sent with `reply.size()`.
-    /// If `size` is not 0, and the value fits, send it with `reply.data()`, or
-    /// `reply.error(ERANGE)` if it doesn't.
+    /// If `size` is 0, the size of the value should be returned in `Xattr::Size(u32)`.
+    /// If `size` is not 0, and the value fits, the value should be returned in `Xattr::Data(Vec<u8>)`.
+    /// If the value does not fit, `Err(Errno::ERANGE)` should be returned.
+    /// The method should return `Ok(Xattr)` on success, or `Err(Errno)` otherwise.
     fn getxattr(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
-        name: &OsStr,
+        name: OsString,
         size: u32,
-        reply: ReplyXattr,
-    ) {
+    ) -> Result<Xattr, Errno> {
         warn!(
             "[Not Implemented] getxattr(ino: {:#x?}, name: {:?}, size: {})",
             ino, name, size
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// List extended attribute names.
-    /// If `size` is 0, the size of the value should be sent with `reply.size()`.
-    /// If `size` is not 0, and the value fits, send it with `reply.data()`, or
-    /// `reply.error(ERANGE)` if it doesn't.
-    fn listxattr(&mut self, _req: &Request<'_>, ino: u64, size: u32, reply: ReplyXattr) {
+    /// If `size` is 0, the size of the names list should be returned in `Xattr::Size(u32)`.
+    /// If `size` is not 0, and the names list fits, it should be returned in `Xattr::Data(Vec<u8>)`.
+    /// If the list does not fit, `Err(Errno::ERANGE)` should be returned.
+    /// The method should return `Ok(Xattr)` on success, or `Err(Errno)` otherwise.
+    fn listxattr(
+        &mut self,
+        req: RequestMeta,
+        ino: u64,
+        size: u32,
+    ) -> Result<Xattr, Errno> {
         warn!(
             "[Not Implemented] listxattr(ino: {:#x?}, size: {})",
             ino, size
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Remove an extended attribute.
-    fn removexattr(&mut self, _req: &Request<'_>, ino: u64, name: &OsStr, reply: ReplyEmpty) {
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
+    fn removexattr(
+        &mut self,
+        req: RequestMeta,
+        ino: u64,
+        name: OsString,
+    ) -> Result<(), Errno> {
         warn!(
             "[Not Implemented] removexattr(ino: {:#x?}, name: {:?})",
             ino, name
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Check file access permissions.
-    /// This will be called for the access() system call. If the 'default_permissions'
+    /// This will be called for the `access()` system call. If the 'default_permissions'
     /// mount option is given, this method is not called. This method is not called
     /// under Linux kernel versions 2.4.x
-    fn access(&mut self, _req: &Request<'_>, ino: u64, mask: i32, reply: ReplyEmpty) {
+    /// The method should return `Ok(())` if access is allowed, or `Err(Errno)` otherwise.
+    fn access(&mut self, req: RequestMeta, ino: u64, mask: i32) -> Result<(), Errno> {
         warn!("[Not Implemented] access(ino: {:#x?}, mask: {})", ino, mask);
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Create and open a file.
     /// If the file does not exist, first create it with the specified mode, and then
-    /// open it. You can use any open flags in the flags parameter except O_NOCTTY.
+    /// open it. You can use any open flags in the `flags` parameter except `O_NOCTTY`.
     /// The filesystem can store any type of file handle (such as a pointer or index)
-    /// in fh, which can then be used across all subsequent file operations including
+    /// in `Open.fh`, which can then be used across all subsequent file operations including
     /// read, write, flush, release, and fsync. Additionally, the filesystem may set
-    /// certain flags like direct_io and keep_cache to change the way the file is
-    /// opened. See fuse_file_info structure in <fuse_common.h> for more details. If
+    /// certain flags like `direct_io` and `keep_cache` in `Open.flags` to change the way the file is
+    /// opened. See `fuse_file_info` structure in `<fuse_common.h>` for more details. If
     /// this method is not implemented or under Linux kernel versions earlier than
-    /// 2.6.15, the mknod() and open() methods will be called instead.
+    /// 2.6.15, the `mknod()` and `open()` methods will be called instead.
+    /// The method should return `Ok((Entry, Open))` with the new entry's attributes and open file information, or `Err(Errno)` otherwise.
     fn create(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         parent: u64,
-        name: &OsStr,
+        name: OsString,
         mode: u32,
         umask: u32,
         flags: i32,
-        reply: ReplyCreate,
-    ) {
+    ) -> Result<(Entry,Open), Errno> {
         warn!(
             "[Not Implemented] create(parent: {:#x?}, name: {:?}, mode: {}, umask: {:#x?}, \
             flags: {:#x?})",
             parent, name, mode, umask, flags
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Test for a POSIX file lock.
+    /// The method should return `Ok(Lock)` with the lock information, or `Err(Errno)` otherwise.
     fn getlk(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         fh: u64,
         lock_owner: u64,
@@ -837,26 +878,26 @@ pub trait Filesystem {
         end: u64,
         typ: i32,
         pid: u32,
-        reply: ReplyLock,
-    ) {
+    ) -> Result<Lock, Errno> {
         warn!(
             "[Not Implemented] getlk(ino: {:#x?}, fh: {}, lock_owner: {}, start: {}, \
             end: {}, typ: {}, pid: {})",
             ino, fh, lock_owner, start, end, typ, pid
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Acquire, modify or release a POSIX file lock.
-    /// For POSIX threads (NPTL) there's a 1-1 relation between pid and owner, but
+    /// For POSIX threads (NPTL) there's a 1-1 relation between `pid` and `owner`, but
     /// otherwise this is not always the case.  For checking lock ownership,
-    /// 'fi->owner' must be used. The l_pid field in 'struct flock' should only be
-    /// used to fill in this field in getlk(). Note: if the locking methods are not
+    /// `fi->owner` must be used. The `l_pid` field in `struct flock` should only be
+    /// used to fill in this field in `getlk()`. Note: if the locking methods are not
     /// implemented, the kernel will still allow file locking to work locally.
     /// Hence these are only interesting for network filesystems and similar.
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
     fn setlk(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         fh: u64,
         lock_owner: u64,
@@ -865,39 +906,40 @@ pub trait Filesystem {
         typ: i32,
         pid: u32,
         sleep: bool,
-        reply: ReplyEmpty,
-    ) {
+    ) -> Result<(), Errno> {
         warn!(
             "[Not Implemented] setlk(ino: {:#x?}, fh: {}, lock_owner: {}, start: {}, \
             end: {}, typ: {}, pid: {}, sleep: {})",
             ino, fh, lock_owner, start, end, typ, pid, sleep
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
     /// Map block index within file to block index within device.
     /// Note: This makes sense only for block device backed filesystems mounted
-    /// with the 'blkdev' option
-    fn bmap(&mut self, _req: &Request<'_>, ino: u64, blocksize: u32, idx: u64, reply: ReplyBmap) {
+    /// with the 'blkdev' option.
+    /// The method should return `Ok(u64)` with the device block index, or `Err(Errno)` otherwise.
+    fn bmap(&mut self, req: RequestMeta, ino: u64, blocksize: u32, idx: u64) -> Result<u64, Errno> {
         warn!(
             "[Not Implemented] bmap(ino: {:#x?}, blocksize: {}, idx: {})",
             ino, blocksize, idx,
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
-    /// control device
+    /// Control device.
+    /// The method should return `Ok(Ioctl)` with the ioctl result, or `Err(Errno)` otherwise.
+    #[cfg(feature = "abi-7-11")]
     fn ioctl(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         fh: u64,
         flags: u32,
         cmd: u32,
-        in_data: &[u8],
+        in_data: Vec<u8>,
         out_size: u32,
-        reply: ReplyIoctl,
-    ) {
+    ) -> Result<Ioctl, Errno> {
         warn!(
             "[Not Implemented] ioctl(ino: {:#x?}, fh: {}, flags: {}, cmd: {}, \
             in_data.len(): {}, out_size: {})",
@@ -908,68 +950,70 @@ pub trait Filesystem {
             in_data.len(),
             out_size,
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
-    /// Poll for events
+    /// Poll for events.
+    /// The method should return `Ok(u32)` with the poll events, or `Err(Errno)` otherwise.
     #[cfg(feature = "abi-7-11")]
     fn poll(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         fh: u64,
         ph: PollHandle,
         events: u32,
         flags: u32,
-        reply: ReplyPoll,
-    ) {
+    ) -> Result<u32, Errno> {
         warn!(
             "[Not Implemented] poll(ino: {:#x?}, fh: {}, ph: {:?}, events: {}, flags: {})",
             ino, fh, ph, events, flags
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
-    /// Preallocate or deallocate space to a file
+    /// Preallocate or deallocate space to a file.
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
     fn fallocate(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         fh: u64,
         offset: i64,
         length: i64,
         mode: i32,
-        reply: ReplyEmpty,
-    ) {
+    ) -> Result<(), Errno> {
         warn!(
             "[Not Implemented] fallocate(ino: {:#x?}, fh: {}, offset: {}, \
             length: {}, mode: {})",
             ino, fh, offset, length, mode
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
-    /// Reposition read/write file offset
+    /// Reposition read/write file offset.
+    /// The method should return `Ok(i64)` with the new offset, or `Err(Errno)` otherwise.
+    #[cfg(feature = "abi-7-24")]
     fn lseek(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino: u64,
         fh: u64,
         offset: i64,
         whence: i32,
-        reply: ReplyLseek,
-    ) {
+    ) -> Result<i64, Errno> {
         warn!(
             "[Not Implemented] lseek(ino: {:#x?}, fh: {}, offset: {}, whence: {})",
             ino, fh, offset, whence
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
-    /// Copy the specified range from the source inode to the destination inode
+    /// Copy the specified range from the source inode to the destination inode.
+    /// The method should return `Ok(u32)` with the number of bytes copied, or `Err(Errno)` otherwise.
     fn copy_file_range(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         ino_in: u64,
         fh_in: u64,
         offset_in: i64,
@@ -978,59 +1022,63 @@ pub trait Filesystem {
         offset_out: i64,
         len: u64,
         flags: u32,
-        reply: ReplyWrite,
-    ) {
+    ) -> Result<u32, Errno> {
         warn!(
             "[Not Implemented] copy_file_range(ino_in: {:#x?}, fh_in: {}, \
             offset_in: {}, ino_out: {:#x?}, fh_out: {}, offset_out: {}, \
             len: {}, flags: {})",
             ino_in, fh_in, offset_in, ino_out, fh_out, offset_out, len, flags
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 
-    /// macOS only: Rename the volume. Set fuse_init_out.flags during init to
-    /// FUSE_VOL_RENAME to enable
+    /// macOS only: Rename the volume. Set `fuse_init_out.flags` during init to
+    /// `FUSE_VOL_RENAME` to enable.
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
     #[cfg(target_os = "macos")]
-    fn setvolname(&mut self, _req: &Request<'_>, name: &OsStr, reply: ReplyEmpty) {
+    fn setvolname(&mut self, req: RequestMeta, name: OsStr) -> Result<(), Errno> {
         warn!("[Not Implemented] setvolname(name: {:?})", name);
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS);
     }
 
-    /// macOS only (undocumented)
+    /// macOS only (undocumented).
+    /// The method should return `Ok(())` on success, or `Err(Errno)` otherwise.
     #[cfg(target_os = "macos")]
     fn exchange(
         &mut self,
-        _req: &Request<'_>,
+        req: RequestMeta,
         parent: u64,
-        name: &OsStr,
+        name: OsString,
         newparent: u64,
-        newname: &OsStr,
-        options: u64,
-        reply: ReplyEmpty,
-    ) {
+        newname: OsString,
+        options: u64
+    ) -> Result<(), Errno> {
         warn!(
             "[Not Implemented] exchange(parent: {:#x?}, name: {:?}, newparent: {:#x?}, \
             newname: {:?}, options: {})",
             parent, name, newparent, newname, options
         );
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS);
     }
 
-    /// macOS only: Query extended times (bkuptime and crtime). Set fuse_init_out.flags
-    /// during init to FUSE_XTIMES to enable
+    /// macOS only: Query extended times (bkuptime and crtime). Set `fuse_init_out.flags`
+    /// during init to `FUSE_XTIMES` to enable.
+    /// The method should return `Ok(XTimes)` with the extended times, or `Err(Errno)` otherwise.
     #[cfg(target_os = "macos")]
-    fn getxtimes(&mut self, _req: &Request<'_>, ino: u64, reply: ReplyXTimes) {
+    fn getxtimes(&mut self, req: RequestMeta, ino: u64) -> Result<XTimes, Errno> {
         warn!("[Not Implemented] getxtimes(ino: {:#x?})", ino);
-        reply.error(ENOSYS);
+        Err(Errno::ENOSYS)
     }
 }
 
 /// Mount the given filesystem to the given mountpoint. This function will
-/// not return until the filesystem is unmounted.
+/// block until the filesystem is unmounted.
 ///
-/// Note that you need to lead each option with a separate `"-o"` string.
-#[deprecated(note = "use mount2() instead")]
+/// `filesystem`: The filesystem implementation.
+/// `mountpoint`: The path to the mountpoint.
+/// `options`: A slice of mount options. Each option needs to be a separate string,
+/// typically starting with `"-o"`. For example: `&[OsStr::new("-o"), OsStr::new("auto_unmount")]`.
+#[deprecated(note = "Use `mount2` instead, which takes a slice of `MountOption` enums for better type safety and clarity.")]
 pub fn mount<FS: Filesystem, P: AsRef<Path>>(
     filesystem: FS,
     mountpoint: P,
@@ -1041,9 +1089,13 @@ pub fn mount<FS: Filesystem, P: AsRef<Path>>(
 }
 
 /// Mount the given filesystem to the given mountpoint. This function will
-/// not return until the filesystem is unmounted.
+/// block until the filesystem is unmounted.
 ///
-/// NOTE: This will eventually replace mount(), once the API is stable
+/// `filesystem`: The filesystem implementation.
+/// `mountpoint`: The path to the mountpoint.
+/// `options`: A slice of `MountOption` enums specifying mount options.
+///
+/// This is the recommended way to mount a FUSE filesystem.
 pub fn mount2<FS: Filesystem, P: AsRef<Path>>(
     filesystem: FS,
     mountpoint: P,
@@ -1053,12 +1105,17 @@ pub fn mount2<FS: Filesystem, P: AsRef<Path>>(
     Session::new(filesystem, mountpoint.as_ref(), options).and_then(|mut se| se.run())
 }
 
-/// Mount the given filesystem to the given mountpoint. This function spawns
-/// a background thread to handle filesystem operations while being mounted
-/// and therefore returns immediately. The returned handle should be stored
-/// to reference the mounted filesystem. If it's dropped, the filesystem will
+/// Mount the given filesystem to the given mountpoint in a background thread.
+/// This function spawns a new thread to handle filesystem operations and returns
+/// immediately. The returned `BackgroundSession` handle should be stored to
+/// keep the filesystem mounted. When the handle is dropped, the filesystem will
 /// be unmounted.
-#[deprecated(note = "use spawn_mount2() instead")]
+///
+/// `filesystem`: The filesystem implementation. Must be `Send + 'static`.
+/// `mountpoint`: The path to the mountpoint.
+/// `options`: A slice of mount options. Each option needs to be a separate string,
+/// typically starting with `"-o"`. For example: `&[OsStr::new("-o"), OsStr::new("auto_unmount")]`.
+#[deprecated(note = "Use `spawn_mount2` instead, which takes a slice of `MountOption` enums for better type safety and clarity.")]
 pub fn spawn_mount<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
     filesystem: FS,
     mountpoint: P,
@@ -1072,13 +1129,17 @@ pub fn spawn_mount<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
     Session::new(filesystem, mountpoint.as_ref(), options.as_ref()).and_then(|se| se.spawn())
 }
 
-/// Mount the given filesystem to the given mountpoint. This function spawns
-/// a background thread to handle filesystem operations while being mounted
-/// and therefore returns immediately. The returned handle should be stored
-/// to reference the mounted filesystem. If it's dropped, the filesystem will
+/// Mount the given filesystem to the given mountpoint in a background thread.
+/// This function spawns a new thread to handle filesystem operations and returns
+/// immediately. The returned `BackgroundSession` handle should be stored to
+/// keep the filesystem mounted. When the handle is dropped, the filesystem will
 /// be unmounted.
 ///
-/// NOTE: This is the corresponding function to mount2.
+/// `filesystem`: The filesystem implementation. Must be `Send + 'static`.
+/// `mountpoint`: The path to the mountpoint.
+/// `options`: A slice of `MountOption` enums specifying mount options.
+///
+/// This is the recommended way to mount a FUSE filesystem in the background.
 pub fn spawn_mount2<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
     filesystem: FS,
     mountpoint: P,

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -20,6 +20,9 @@
 
 #![warn(missing_debug_implementations)]
 #![allow(missing_docs)]
+// TODO: fix all these non camel case types
+#![allow(non_camel_case_types)]
+
 
 #[cfg(feature = "abi-7-9")]
 use crate::consts::{FATTR_ATIME_NOW, FATTR_MTIME_NOW};
@@ -136,10 +139,15 @@ pub struct fuse_kstatfs {
 #[repr(C)]
 #[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable)]
 pub struct fuse_file_lock {
+    /// start of locked byte range
     pub start: u64,
+    /// end of locked byte range
     pub end: u64,
     // NOTE: this field is defined as u32 in fuse_kernel.h in libfuse. However, it is treated as signed
+    // TODO enum {F_RDLCK, F_WRLCK, F_UNLCK}
+    /// kind of lock (read and/or write) 
     pub typ: i32,
+    /// PID of process blocking our lock
     pub pid: u32,
 }
 
@@ -530,7 +538,7 @@ pub struct fuse_forget_in {
 
 #[cfg(feature = "abi-7-16")]
 #[repr(C)]
-#[derive(Debug, FromBytes, KnownLayout, Immutable)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable, Clone)]
 pub struct fuse_forget_one {
     pub nodeid: u64,
     pub nlookup: u64,

--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -225,6 +225,7 @@ impl Errno {
     #[cfg(not(target_os = "linux"))]
     pub const NO_XATTR: Errno = Self::ENOATTR;
 
+    /// Use this to try to convert an integer error code into a fuser Errno
     pub fn from_i32(err: i32) -> Errno {
         err.try_into().ok().map(Errno).unwrap_or(Errno::EIO)
     }

--- a/src/ll/reply.rs
+++ b/src/ll/reply.rs
@@ -222,6 +222,7 @@ impl<'a> Response<'a> {
     }
 
     // TODO: Are you allowed to send data while result != 0?
+    #[cfg(feature = "abi-7-11")]
     pub(crate) fn new_ioctl(result: i32, data: &[IoSlice<'_>]) -> Self {
         let r = abi::fuse_ioctl_out {
             result,
@@ -257,6 +258,7 @@ impl<'a> Response<'a> {
         Self::from_struct(&r)
     }
 
+    #[cfg(feature = "abi-7-24")]
     pub(crate) fn new_lseek(offset: i64) -> Self {
         let r = abi::fuse_lseek_out { offset };
         Self::from_struct(&r)
@@ -438,6 +440,7 @@ impl DirEntList {
     }
 }
 
+#[cfg(feature = "abi-7-21")]
 #[derive(Debug)]
 pub struct DirEntryPlus<T: AsRef<Path>> {
     #[allow(unused)] // We use `attr.ino` instead
@@ -450,6 +453,7 @@ pub struct DirEntryPlus<T: AsRef<Path>> {
     attr_valid: Duration,
 }
 
+#[cfg(feature = "abi-7-21")]
 impl<T: AsRef<Path>> DirEntryPlus<T> {
     pub fn new(
         ino: INodeNo,
@@ -473,8 +477,11 @@ impl<T: AsRef<Path>> DirEntryPlus<T> {
 }
 
 /// Used to respond to [ReadDir] requests.
+#[cfg(feature = "abi-7-21")]
 #[derive(Debug)]
 pub struct DirEntPlusList(EntListBuf);
+
+#[cfg(feature = "abi-7-21")]
 impl From<DirEntPlusList> for Response<'_> {
     fn from(l: DirEntPlusList) -> Self {
         assert!(l.0.buf.len() <= l.0.max_size);
@@ -482,6 +489,7 @@ impl From<DirEntPlusList> for Response<'_> {
     }
 }
 
+#[cfg(feature = "abi-7-21")]
 impl DirEntPlusList {
     pub(crate) fn new(max_size: usize) -> Self {
         Self(EntListBuf::new(max_size))


### PR DESCRIPTION
commit 99922baa2c11ee5317cccae8cdfd75099d62ac65
Author: Richard Lawrence <rarensu@tamu.edu>
Date:   Tue Jun 24 11:26:20 2025 -0500

    clippy fixes

commit 0edf3bddbfaae68aecb0f98d4628a3bce70d5a61
Author: Richard Lawrence <rarensu@tamu.edu>
Date:   Tue Jun 24 11:21:38 2025 -0500

    type fixes

commit e55a4313c48064a66f4acc5308ab5a84c79608b2
Author: Richard Lawrence <rarensu@tamu.edu>
Date:   Tue Jun 24 11:10:59 2025 -0500

    Cleanup after squash

commit 5bc7805217035c618658e0bdaee0a128060de36a
Author: Richard Lawrence <rarensu@tamu.edu>
Date:   Tue Jun 24 08:42:40 2025 -0500

    Squashed commit of the following:

    commit 159e2daeb05b09c9af1ebd23ca1bfc85daeb25f1
    Author: google-labs-jules[bot] <161369871+google-labs-jules[bot]@users.noreply.github.com>
    Date:   Tue Jun 24 01:05:50 2025 +0000

        Update documentation for API refactor

        - Update doc comments in src/lib.rs for Filesystem trait, ForgetMe struct, and mount functions to align with the new return-result API.
        - Add CHANGELOG entry for the major API refactor where Filesystem methods now return Result instead of using reply callbacks.
        - Remove commented-out code in examples/passthrough.rs that referred to the old reply API.
        - Noted a comment in src/ll/request.rs (SYMLINK_READ_BUF_SIZE) that may need further update regarding low-level reply mechanisms.

    commit 9360efe9d252ab4f3c363bd1c019e49834991077
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 19:41:48 2025 -0500

        short test abi 7 36

    commit 4e12af419ff26ef7cdadf3ae220a648737b09c64
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 19:41:36 2025 -0500

        examples with forgetme

    commit 672ea71bc57686b885eef3e48e7f96851cef27c0
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 19:34:14 2025 -0500

        clippy fix and new ForgetMe

    commit ce9d02a6e526778342f00132301c7dde66e8a487
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 18:47:43 2025 -0500

        cargo clippy elided some lifetimes

    commit 0c4ba7537a73a63ce9ed2d70c9514464a15839c9
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 18:23:03 2025 -0500

        preparing for clippy lint

    commit 6b83f17b5d545dd8a50b6781935f2a509e7365b8
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 16:34:41 2025 -0500

        wrote a new message

    commit 434afb6e5a25674aead0f1a7b16cae27ed0d54e0
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 16:29:56 2025 -0500

        cleanup reply.rs

    commit a7082d6edea5799947c4baa5acefeb302c10959a
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 15:57:27 2025 -0500

        last tests for abi-7-36

    commit 90e191c0cd035411b70e91e164f27e8fd2e707d3
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 14:59:11 2025 -0500

        almost got tests to pass for abi-7-40

    commit 18b4728a2f8141c64333628205ab03358800ee74
    Merge: b386013 b79de3f
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 13:31:49 2025 -0500

        Merge branch 'to-be-merged-with-master' into merged-from-master

    commit b79de3f8587ff8ec75bc2b477908572dea1b8c93
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 13:13:07 2025 -0500

        test corrections

    commit 105a41164297ab6ca93a5ee6f3e2ae43612d4130
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 12:48:07 2025 -0500

        fixes for passthrough default impl

    commit 3f507be20b9643b87acaef3385d2a272d9d0b4e6
    Author: google-labs-jules[bot] <161369871+google-labs-jules[bot]@users.noreply.github.com>
    Date:   Mon Jun 23 15:37:50 2025 +0000

        Refactor examples to use Result API

        Updated all FUSE example files (hello, ioctl, notify_inval_entry, notify_inval_inode, poll) to align with the new API where Filesystem trait methods return a Result<T, Errno> instead of using reply callbacks.

        Changes include:
        - Modified function signatures and return types.
        - Updated import statements for new/removed types.
        - Adjusted method logic to correctly construct return values.
        - Fixed various compilation errors, including borrow checker issues and struct field usage.
        - Removed unused libc imports for a cleaner build.

    commit b2d11528835b971aea8dc2f628647681ed7e9129
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 10:10:12 2025 -0500

        fix dirplus size

    commit 1be246c6bc6f20331ba58dc13ee231b99100ab9b
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 10:06:50 2025 -0500

        style, doc, and max_bytes

    commit 24840852e93212497672016600d08cc9d9be672b
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon Jun 23 09:20:09 2025 -0500

        fixes for simple example in usermode

    commit d73d43f7aba92aa62df92a715748e8442cc16b5d
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Sun Jun 22 20:25:56 2025 -0500

        corrections based on bugs found in simple.rs

    commit 10cc78c818fdb418487160e7882f304a6f4dccaf
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Fri Jun 13 23:26:26 2025 -0500

        example corrections simple hello

    commit 6e2095091e10eb12a82109a6fb118a7ebba814bf
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Fri Jun 13 18:56:02 2025 -0500

        example corrections notify

    commit 3d4df0e5eae74f97fbb4bdb469f0a4a374097615
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Fri Jun 13 17:42:04 2025 -0500

        example corrections simple

    commit bbc6b68a3a11d0858cb410e94ca0ca181ec5b996
    Author: google-labs-jules[bot] <161369871+google-labs-jules[bot]@users.noreply.github.com>
    Date:   Wed May 28 19:33:29 2025 +0000

        I've addressed several compilation errors that arose when the `abi-7-24` feature flag was active, primarily within `src/request.rs` and `src/reply.rs`.

        Here's what I changed:

        -   In `src/reply.rs`, I corrected conditional imports and definitions for types related to the `abi-7-21` feature (like `DirEntPlusList` and `Generation`) to make sure they are available when `abi-7-21` is active.
        -   I removed an incorrect and unnecessary import of `ReplyDirectoryPlus` from `src/request.rs`.
        -   In `src/request.rs`, I fixed a type mismatch in the `Write` operation by explicitly converting data to `Vec<u8>` using `.to_vec()`.
        -   I also corrected method arguments in `src/request.rs` for:
            -   `Lseek`: I made sure `self.meta` is passed instead of `self`.
            -   `Rename2`: I ensured `OsString` is passed by converting arguments using `.to_os_string()`.
        -   I addressed potential `use of moved value` errors for `replyhandler` in `src/request.rs`.

        With these adjustments, `examples/simple.rs` now compiles successfully when you use the `--features=abi-7-24` flag. There are still errors in other example files, but those are outside the scope of this particular fix.

    commit f2b620b457416197c2c512282f890098d89df0e6
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Wed May 28 14:03:51 2025 -0500

        Update simple.rs

        remove the last reply()

    commit dae2e1d2a90af2fa6e73cdefc0711e26741e6a0a
    Author: google-labs-jules[bot] <161369871+google-labs-jules[bot]@users.noreply.github.com>
    Date:   Wed May 28 18:57:09 2025 +0000

        Refactor examples/simple.rs for Filesystem trait (ongoing)

        This commit continues the work of updating `examples/simple.rs` to use the
        new return style of the `Filesystem` trait.

        Work completed in this set of changes:
        - I verified that the following functions in `examples/simple.rs` conform to the new trait requirements (most were already updated):
            - write (signature for `data` and unwrap handling were confirmed updated)
            - release - opendir - readdir - releasedir - statfs - For these functions, my verification included: - Correct return types (`Result<RelevantStruct, Errno>`). - Direct `return Ok(...)` or `return Err(...)`. - Updated function parameter types where necessary. - Robust error handling for operations that could panic.

        I identified Changes for `setxattr` function (not yet applied due to turn limit):
        - Change `value: &[u8]` parameter to `value: Vec<u8>`.
        - Update `attrs.xattrs.insert` to use the `Vec<u8> value` directly.
        - Refine error handling for `get_inode` to use a `match` and specifically return `Errno::ENOENT` when appropriate, rather than a generic `Errno::EBADF`.

        The following functions were confirmed/updated in previous commits:
        `lookup`, `getattr`, `setattr`, `readlink`, `mknod`, `mkdir`, `unlink`, `rmdir`, `symlink`, `rename`, `open`, `read`.

        Further work is needed on `setxattr` (to apply identified changes), `link` (retry), `getxattr`, `listxattr`, `removexattr`, `access`, `create`, `fallocate`, and `copy_file_range`.

    commit 3b0282edf752ab4470ac628459df152af903111d
    Author: google-labs-jules[bot] <161369871+google-labs-jules[bot]@users.noreply.github.com>
    Date:   Wed May 28 17:52:54 2025 +0000

        I'm continuing to refactor `examples/simple.rs` for the `Filesystem` trait.

        In this update:
        - I've verified that the `rename`, `open`, and `read` functions in `examples/simple.rs` now align with the new trait requirements. Most of these were already updated.
        - For these functions, I ensured:
            - Correct return types (`Result<RelevantStruct, Errno>`).
            - Direct use of `return Ok(...)` or `return Err(...)`. - Updated function parameter types where necessary. - Robust error handling for operations that might cause issues. - I decided to skip modifying the `link` function for now due to some earlier difficulties, but I plan to revisit it.

        I've also identified what needs to change for the `write` function (though I haven't applied these changes yet):
        - The `data: &[u8]` parameter should be changed to `data: Vec<u8>`.
        - Calls to `unwrap()` on `seek`, `write_all`, and `get_inode` should be replaced with `map_err` to return `Errno::EIO` or a similar error.

        The following functions were confirmed or updated in previous work:
        `lookup`, `getattr`, `setattr`, `readlink`, `mknod`, `mkdir`, `unlink`, `rmdir`, `symlink`.

        There's still more to do on the `write` and `link` functions (I'll try `link` again), as well as `release`, `opendir`, `readdir`, `releasedir`, `statfs`, `setxattr`, `getxattr`, `listxattr`, `removexattr`, `access`, `create`, `fallocate`, and `copy_file_range`.

    commit d83ba7eefd1d12a32cf5cfa7073d901d9fa3f7bd
    Author: google-labs-jules[bot] <161369871+google-labs-jules[bot]@users.noreply.github.com>
    Date:   Wed May 28 17:19:39 2025 +0000

        Refactor examples/simple.rs for updated Filesystem trait

        This commit addresses the issue of updating `examples/simple.rs` to use the
        new return style of the `Filesystem` trait (returning `Result<SomeStruct, Errno>`
        instead of using a `reply` object).

        Work I completed:
        - I verified that the following functions in `examples/simple.rs` already conform to the new trait requirements, likely due to prior updates:
            - lookup
            - getattr - setattr - readlink - mknod - mkdir - unlink - rmdir - symlink - For these functions, I ensured: - Correct return types (`Result<RelevantStruct, Errno>`). - Direct `return Ok(...)` or `return Err(...)` instead of `reply.entry()`, `reply.ok()`, `reply.error()`, etc. - Updated function parameter types where necessary (e.g., `OsString` instead of `&OsStr`). - Robust error handling for operations that could panic (e.g. replacing `.unwrap()` with `map_err` or `match`). - Correct usage of fields from `RequestMeta` (e.g. `req.uid` instead of `req.uid()`).

        The remaining functions in `simple.rs` that implement the `Filesystem` trait still need to be updated. This commit covers the verification and confirmation of the already updated functions.

    commit 516366cdb7e56f38935d71258ee860712b9e2c76
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon May 26 15:52:08 2025 +0000

        massive updates for simple.rs

    commit 39b44f566a7f3cd3f91a039085f8452c73f2d588
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon May 26 03:55:29 2025 +0000

        first pass on examples

    commit 348390cae7f0669fe54f76b055ed9733416b1be4
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Mon May 26 02:45:11 2025 +0000

        more tidying

    commit 33ff94b3e50733e03244669627a9fa3bcb2e7363
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Sun May 25 15:58:06 2025 +0000

        continued

    commit a8c13bf2ee845b82c7cf59e9137a643454f577c5
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Sun May 25 14:59:25 2025 +0000

        continued

    commit 5b78e223d081a8cbf685de6a94f424c5da0bbc96
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Sat May 24 15:50:21 2025 +0000

        continued

    commit 1dbd865262791379bf360dfe611356f7d4f83e48
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Sat May 24 15:35:58 2025 +0000

        more edits for return

    commit c950f8cbab72a8050e5a540dbf3c3017d33614ae
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Fri May 23 23:59:29 2025 +0000

        more edits for return

    commit d1a5fc9dbe4fb0578cd87c9ec5b18621a0d19680
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Tue May 20 23:40:34 2025 +0000

        more refactoring

    commit b9292556ce824637c3addc414c72318e4f445851
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Fri May 16 22:41:50 2025 +0000

        refactor in progress

    commit 54f04187f4cb579d90ef5c731e4754f05e92ad7a
    Author: Richard Lawrence <rarensu@tamu.edu>
    Date:   Fri May 16 02:44:46 2025 +0000

        refactor plan